### PR TITLE
Update executable generator to include all test classes

### DIFF
--- a/tasks/templates/dev.erb
+++ b/tasks/templates/dev.erb
@@ -2,9 +2,8 @@
 
 require "bundler/setup"
 require_relative "../lib/model_context_protocol"
-require_relative "../spec/support/prompts/test_prompt"
-require_relative "../spec/support/test_resource"
-require_relative "../spec/support/tools/test_tool_with_text_response"
+
+Dir[File.join(__dir__, "../spec/support/**/*.rb")].each { |file| require file }
 
 server = ModelContextProtocol::Server.new do |config|
   config.name = "MCP Development Server"
@@ -17,10 +16,16 @@ server = ModelContextProtocol::Server.new do |config|
 
     resources list_changed: true, subscribe: true do
       register TestResource
+      register TestBinaryResource
     end
 
     tools list_changed: true do
       register TestToolWithTextResponse
+      register TestToolWithImageResponse
+      register TestToolWithImageResponseDefaultMimeType
+      register TestToolWithResourceResponse
+      register TestToolWithResourceResponseDefaultMimeType
+      register TestToolWithToolErrorResponse
     end
   end
 end


### PR DESCRIPTION
This updates the generated executable to include all of the example classes. This should help us in testing out the different responses with the MCP inspector.
