### PR TITLE
Fix spec support classes for use in MCP inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ class TestBinaryResource < ModelContextProtocol::Server::Resource
 
   def call
     # In a real implementation, we would retrieve the binary resource
-    data = "base64data"
+    data = "dGVzdA=="
     respond_with :binary, blob: data
   end
 end

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ class TestToolWithImageResponse < ModelContextProtocol::Server::Tool
     end
 
     # In a real implementation, we would generate an actual chart
-    chart_data = "base64encodeddata"
+    # This is a small valid base64 encoded string (represents "test")
+    chart_data = "dGVzdA=="
     respond_with :image, data: chart_data, mime_type:
   end
 end
@@ -253,7 +254,8 @@ class TestToolWithImageResponseDefaultMimeType < ModelContextProtocol::Server::T
 
   def call
     # In a real implementation, we would generate an actual chart
-    chart_data = "base64encodeddata"
+    # This is a small valid base64 encoded string (represents "test")
+    chart_data = "dGVzdA=="
     respond_with :image, data: chart_data
   end
 end

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
         type: "object",
         properties: {
           number: {
-            type: "integer",
+            type: "string",
           }
         },
         required: ["number"]
@@ -237,7 +237,7 @@ If you don't provide a mime type, it will default to `image/png`.
 class TestToolWithImageResponseDefaultMimeType < ModelContextProtocol::Server::Tool
   with_metadata do
     {
-      name: "custom-chart-generator",
+      name: "other-custom-chart-generator",
       description: "Generates a chart",
       inputSchema: {
         type: "object",

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         expect(response.serialized).to eq(
           contents: [
             {
-              blob: "base64data",
+              blob: "dGVzdA==",
               mimeType: "image/jpeg",
               uri: "resource://project-logo"
             }

--- a/spec/lib/model_context_protocol/server/tool_spec.rb
+++ b/spec/lib/model_context_protocol/server/tool_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     end
 
     context "when input schema validation succeeds" do
-      let(:valid_params) { {"number" => 21} }
+      let(:valid_params) { {"number" => "21"} }
 
       it "instantiates the tool with the provided parameters" do
         expect(TestToolWithTextResponse).to receive(:new).with(valid_params).and_call_original
@@ -70,15 +70,15 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     end
 
     it "stores the parameters" do
-      tool = TestToolWithTextResponse.new({"number" => 42})
-      expect(tool.params).to eq({"number" => 42})
+      tool = TestToolWithTextResponse.new({"number" => "42"})
+      expect(tool.params).to eq({"number" => "42"})
     end
   end
 
   describe "responses" do
     describe "text response" do
       it "formats text response correctly" do
-        params = {"number" => 21}
+        params = {"number" => "21"}
         response = TestToolWithTextResponse.call(params)
         expect(response.serialized).to eq(
           content: [
@@ -184,7 +184,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
           type: "object",
           properties: {
             number: {
-              type: "integer"
+              type: "string"
             }
           },
           required: ["number"]
@@ -202,7 +202,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
           type: "object",
           properties: {
             number: {
-              type: "integer"
+              type: "string"
             }
           },
           required: ["number"]

--- a/spec/lib/model_context_protocol/server/tool_spec.rb
+++ b/spec/lib/model_context_protocol/server/tool_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
           content: [
             {
               type: "image",
-              data: "base64encodeddata",
+              data: "dGVzdA==",
               mimeType: "image/jpeg"
             }
           ],
@@ -115,7 +115,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
           content: [
             {
               type: "image",
-              data: "base64encodeddata",
+              data: "dGVzdA==",
               mimeType: "image/png"
             }
           ],

--- a/spec/support/resources/test_binary_resource.rb
+++ b/spec/support/resources/test_binary_resource.rb
@@ -10,7 +10,8 @@ class TestBinaryResource < ModelContextProtocol::Server::Resource
 
   def call
     # In a real implementation, we would retrieve the binary resource
-    data = "base64data"
+    # This is a small valid base64 encoded string (represents "test")
+    data = "dGVzdA=="
     respond_with :binary, blob: data
   end
 end

--- a/spec/support/tools/test_tool_with_image_response.rb
+++ b/spec/support/tools/test_tool_with_image_response.rb
@@ -32,7 +32,8 @@ class TestToolWithImageResponse < ModelContextProtocol::Server::Tool
     end
 
     # In a real implementation, we would generate an actual chart
-    chart_data = "base64encodeddata"
+    # This is a small valid base64 encoded string (represents "test")
+    chart_data = "dGVzdA=="
     respond_with :image, data: chart_data, mime_type:
   end
 end

--- a/spec/support/tools/test_tool_with_image_response_default_mime_type.rb
+++ b/spec/support/tools/test_tool_with_image_response_default_mime_type.rb
@@ -1,7 +1,7 @@
 class TestToolWithImageResponseDefaultMimeType < ModelContextProtocol::Server::Tool
   with_metadata do
     {
-      name: "custom-chart-generator",
+      name: "other-custom-chart-generator",
       description: "Generates a chart",
       inputSchema: {
         type: "object",

--- a/spec/support/tools/test_tool_with_image_response_default_mime_type.rb
+++ b/spec/support/tools/test_tool_with_image_response_default_mime_type.rb
@@ -18,7 +18,8 @@ class TestToolWithImageResponseDefaultMimeType < ModelContextProtocol::Server::T
 
   def call
     # In a real implementation, we would generate an actual chart
-    chart_data = "base64encodeddata"
+    # This is a small valid base64 encoded string (represents "test")
+    chart_data = "dGVzdA=="
     respond_with :image, data: chart_data
   end
 end

--- a/spec/support/tools/test_tool_with_text_response.rb
+++ b/spec/support/tools/test_tool_with_text_response.rb
@@ -7,7 +7,7 @@ class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
         type: "object",
         properties: {
           number: {
-            type: "integer"
+            type: "string"
           }
         },
         required: ["number"]


### PR DESCRIPTION
This PR fixes a few of the spec support classes so we can use them all in the MCP inspector without any issues.

- **Fix TestBinaryResource class**
- **Fix tool image response classes**
- **Fix remaining tool issues**
