### PR TITLE
Implement resource templates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     model-context-protocol-rb (0.3.1)
+      addressable (~> 2.8)
       json-schema (~> 5.1)
 
 GEM

--- a/lib/model_context_protocol.rb
+++ b/lib/model_context_protocol.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+require "addressable/template"
 
 Dir[File.join(__dir__, "model_context_protocol/", "**", "*.rb")].sort.each { |file| require_relative file }
 

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -65,7 +65,17 @@ module ModelContextProtocol
       end
 
       router.map("resources/read") do |message|
-        configuration.registry.find_resource(message["params"]["uri"]).call
+        uri = message["params"]["uri"]
+        if (resource = configuration.registry.find_resource(uri))
+          resource.call
+        else
+          resource_template = configuration.registry.find_resource_template(uri)
+          resource_template&.call(uri)
+        end
+      end
+
+      router.map("resources/templates/list") do |message|
+        configuration.registry.resource_templates_data
       end
 
       router.map("prompts/list") do

--- a/lib/model_context_protocol/server/resource.rb
+++ b/lib/model_context_protocol/server/resource.rb
@@ -60,7 +60,7 @@ module ModelContextProtocol
       end
 
       def metadata
-        {name: @name, description: @description, mime_type: @mime_type, uri: @uri}
+        {name: @name, description: @description, mimeType: @mime_type, uri: @uri}
       end
     end
   end

--- a/lib/model_context_protocol/server/resource_template.rb
+++ b/lib/model_context_protocol/server/resource_template.rb
@@ -1,0 +1,76 @@
+module ModelContextProtocol
+  class Server::ResourceTemplate
+    attr_reader :mime_type, :uri, :uri_template
+
+    def initialize(uri)
+      @mime_type = self.class.mime_type
+      @uri = uri
+      @uri_template = self.class.uri_template
+    end
+
+    def call
+      raise NotImplementedError, "Subclasses must implement the call method"
+    end
+
+    def extracted_uri
+      return @extracted_uri if defined?(@extracted_uri)
+
+      addressable_uri = Addressable::URI.parse(uri)
+      template = Addressable::Template.new(uri_template)
+      @extracted_uri = template.extract(addressable_uri)
+    end
+
+    TextResponse = Data.define(:resource, :text, :uri) do
+      def serialized
+        {contents: [{mimeType: resource.mime_type, text:, uri:}]}
+      end
+    end
+    private_constant :TextResponse
+
+    BinaryResponse = Data.define(:blob, :resource, :uri) do
+      def serialized
+        {contents: [{blob:, mimeType: resource.mime_type, uri:}]}
+      end
+    end
+    private_constant :BinaryResponse
+
+    private def respond_with(type, **options)
+      case [type, options]
+      in [:text, {text:}]
+        TextResponse[resource: self, text:, uri:]
+      in [:binary, {blob:}]
+        BinaryResponse[blob:, resource: self, uri:]
+      else
+        raise ModelContextProtocol::Server::ResponseArgumentsError, "Invalid arguments: #{type}, #{options}"
+      end
+    end
+
+    class << self
+      attr_reader :name, :description, :mime_type, :uri_template
+
+      def with_metadata(&block)
+        metadata = instance_eval(&block)
+
+        @name = metadata[:name]
+        @description = metadata[:description]
+        @mime_type = metadata[:mime_type]
+        @uri_template = metadata[:uri_template]
+      end
+
+      def inherited(subclass)
+        subclass.instance_variable_set(:@name, @name)
+        subclass.instance_variable_set(:@description, @description)
+        subclass.instance_variable_set(:@mime_type, @mime_type)
+        subclass.instance_variable_set(:@uri_template, @uri_template)
+      end
+
+      def call(uri)
+        new(uri).call
+      end
+
+      def metadata
+        {name: @name, description: @description, mimeType: @mime_type, uriTemplate: @uri_template}
+      end
+    end
+  end
+end

--- a/model-context-protocol-rb.gemspec
+++ b/model-context-protocol-rb.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "json-schema", "~> 5.1"
+  spec.add_dependency "addressable", "~> 2.8"
 end

--- a/spec/lib/model_context_protocol/server/registry_spec.rb
+++ b/spec/lib/model_context_protocol/server/registry_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
 
       expect(registry.instance_variable_get(:@prompts)).to be_empty
       expect(registry.instance_variable_get(:@resources)).to be_empty
+      expect(registry.instance_variable_get(:@resource_templates)).to be_empty
       expect(registry.instance_variable_get(:@tools)).to be_empty
     end
 
@@ -49,6 +50,18 @@ RSpec.describe ModelContextProtocol::Server::Registry do
       expect(resources.first[:mimeType]).to eq("text/plain")
     end
 
+    it "registers a resource template class" do
+      registry.register(TestResourceTemplate)
+      resource_templates = registry.instance_variable_get(:@resource_templates)
+
+      expect(resource_templates.size).to eq(1)
+      expect(resource_templates.first[:klass]).to eq(TestResourceTemplate)
+      expect(resource_templates.first[:name]).to eq("Test Resource Template")
+      expect(resource_templates.first[:uriTemplate]).to eq("resource://{name}")
+      expect(resource_templates.first[:description]).to eq("A test resource template")
+      expect(resource_templates.first[:mimeType]).to eq("text/plain")
+    end
+
     it "registers a tool class" do
       registry.register(TestToolWithTextResponse)
       tools = registry.instance_variable_get(:@tools)
@@ -78,6 +91,10 @@ RSpec.describe ModelContextProtocol::Server::Registry do
           register TestResource
         end
 
+        resource_templates do
+          register TestResourceTemplate
+        end
+
         tools list_changed: true do
           register TestToolWithTextResponse
         end
@@ -85,6 +102,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
 
       expect(registry.instance_variable_get(:@prompts).size).to eq(1)
       expect(registry.instance_variable_get(:@resources).size).to eq(1)
+      expect(registry.instance_variable_get(:@resource_templates).size).to eq(1)
       expect(registry.instance_variable_get(:@tools).size).to eq(1)
       expect(registry.prompts_options).to eq(list_changed: true)
       expect(registry.resources_options).to eq(list_changed: true, subscribe: true)
@@ -101,6 +119,10 @@ RSpec.describe ModelContextProtocol::Server::Registry do
 
         resources do
           register TestResource
+        end
+
+        resource_templates do
+          register TestResourceTemplate
         end
 
         tools do
@@ -129,6 +151,18 @@ RSpec.describe ModelContextProtocol::Server::Registry do
       end
     end
 
+    describe "#find_resource_template" do
+      it "returns the resource template class when a matching URI is found" do
+        uri = Addressable::URI.parse("resource://test-name")
+        expect(registry.find_resource_template(uri)).to eq(TestResourceTemplate)
+      end
+
+      it "returns nil when no matching template is found" do
+        uri = Addressable::URI.parse("invalid://test-name")
+        expect(registry.find_resource_template(uri)).to be_nil
+      end
+    end
+
     describe "#find_tool" do
       it "returns the tool class when found" do
         expect(registry.find_tool("double")).to eq(TestToolWithTextResponse)
@@ -149,6 +183,10 @@ RSpec.describe ModelContextProtocol::Server::Registry do
 
         resources do
           register TestResource
+        end
+
+        resource_templates do
+          register TestResourceTemplate
         end
 
         tools do
@@ -188,6 +226,39 @@ RSpec.describe ModelContextProtocol::Server::Registry do
           )
           expect(result.resources.first).not_to have_key(:klass)
         end
+      end
+    end
+
+    describe "#resource_templates_data" do
+      it "returns a hash with resource templates array without klass references" do
+        result = registry.resource_templates_data
+
+        aggregate_failures do
+          expect(result).to be_a(ModelContextProtocol::Server::Registry::ResourceTemplatesData)
+          expect(result.resource_templates).to be_an(Array)
+          expect(result.resource_templates.first).to include(
+            name: "Test Resource Template",
+            uriTemplate: "resource://{name}",
+            description: "A test resource template",
+            mimeType: "text/plain"
+          )
+          expect(result.resource_templates.first).not_to have_key(:klass)
+        end
+      end
+
+      it "serializes resource templates data properly" do
+        result = registry.resource_templates_data.serialized
+
+        expect(result).to eq(
+          resourceTemplates: [
+            {
+              name: "Test Resource Template",
+              uriTemplate: "resource://{name}",
+              description: "A test resource template",
+              mimeType: "text/plain"
+            }
+          ]
+        )
       end
     end
 

--- a/spec/lib/model_context_protocol/server/registry_spec.rb
+++ b/spec/lib/model_context_protocol/server/registry_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
       expect(resources.first[:name]).to eq("Test Resource")
       expect(resources.first[:uri]).to eq("resource://test-resource")
       expect(resources.first[:description]).to eq("A test resource")
-      expect(resources.first[:mime_type]).to eq("text/plain")
+      expect(resources.first[:mimeType]).to eq("text/plain")
     end
 
     it "registers a tool class" do
@@ -184,7 +184,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
             name: "Test Resource",
             uri: "resource://test-resource",
             description: "A test resource",
-            mime_type: "text/plain"
+            mimeType: "text/plain"
           )
           expect(result.resources.first).not_to have_key(:klass)
         end

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
       expect(TestResource.metadata).to eq(
         name: "Test Resource",
         description: "A test resource",
-        mime_type: "text/plain",
+        mimeType: "text/plain",
         uri: "resource://test-resource"
       )
     end

--- a/spec/lib/model_context_protocol/server/resource_template_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_template_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::ResourceTemplate do
+  describe ".call" do
+    it "returns the response from the instance's call method" do
+      response = TestResourceTemplate.call("resource://test-resource")
+      aggregate_failures do
+        expect(response.text).to eq("Here's the resource name you requested: test-resource")
+        expect(response.serialized).to eq(
+          contents: [
+            {
+              mimeType: "text/plain",
+              text: "Here's the resource name you requested: test-resource",
+              uri: "resource://test-resource"
+            }
+          ]
+        )
+      end
+    end
+  end
+
+  describe "responses" do
+    describe "text response" do
+      it "formats text responses correctly" do
+        response = TestResourceTemplate.call("resource://test-resource")
+        expect(response.serialized).to eq(
+          contents: [
+            {
+              mimeType: "text/plain",
+              text: "Here's the resource name you requested: test-resource",
+              uri: "resource://test-resource"
+            }
+          ]
+        )
+      end
+    end
+
+    describe "binary response" do
+      it "formats binary responses correctly" do
+        response = TestBinaryResourceTemplate.call("resource://project-logo")
+
+        expect(response.serialized).to eq(
+          contents: [
+            {
+              blob: "dGVzdA==",
+              mimeType: "image/jpeg",
+              uri: "resource://project-logo"
+            }
+          ]
+        )
+      end
+    end
+  end
+
+  describe "with_metadata" do
+    it "sets the class metadata" do
+      aggregate_failures do
+        expect(TestResourceTemplate.name).to eq("Test Resource Template")
+        expect(TestResourceTemplate.description).to eq("A test resource template")
+        expect(TestResourceTemplate.mime_type).to eq("text/plain")
+        expect(TestResourceTemplate.uri_template).to eq("resource://{name}")
+      end
+    end
+  end
+
+  describe "metadata" do
+    it "returns class metadata" do
+      expect(TestResourceTemplate.metadata).to eq(
+        name: "Test Resource Template",
+        description: "A test resource template",
+        mimeType: "text/plain",
+        uriTemplate: "resource://{name}"
+      )
+    end
+  end
+end

--- a/spec/support/resource_templates/test_binary_resource_template.rb
+++ b/spec/support/resource_templates/test_binary_resource_template.rb
@@ -1,0 +1,16 @@
+class TestBinaryResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
+  with_metadata do
+    {
+      name: "Image Search",
+      description: "Returns an image given a filename",
+      mime_type: "image/jpeg",
+      uri_template: "resource://{filename}"
+    }
+  end
+
+  def call
+    # In a real implementation, we would retrieve the binary resource using extracted_uri["filename"]
+    data = "dGVzdA=="
+    respond_with :binary, blob: data
+  end
+end

--- a/spec/support/resource_templates/test_resource_template.rb
+++ b/spec/support/resource_templates/test_resource_template.rb
@@ -1,0 +1,15 @@
+class TestResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
+  with_metadata do
+    {
+      name: "Test Resource Template",
+      description: "A test resource template",
+      mime_type: "text/plain",
+      uri_template: "resource://{name}"
+    }
+  end
+
+  def call
+    result = "Here's the resource name you requested: #{extracted_uri["name"]}"
+    respond_with :text, text: result
+  end
+end

--- a/tasks/templates/dev.erb
+++ b/tasks/templates/dev.erb
@@ -19,6 +19,11 @@ server = ModelContextProtocol::Server.new do |config|
       register TestBinaryResource
     end
 
+    resource_templates do
+      register TestResourceTemplate
+      register TestBinaryResourceTemplate
+    end
+
     tools list_changed: true do
       register TestToolWithTextResponse
       register TestToolWithImageResponse


### PR DESCRIPTION
This PR implements [resource templates](https://modelcontextprotocol.io/specification/2024-11-05/server/resources#resource-templates).

- **Added addressable dependency**
- **Implemented basic resource template class**
- **Fix mimeType on resource metadata**
- **Register resource templates**
- **Route incoming messages to resource templates**
- **Update README**
- **Update executable generator**
