### PR TITLE
Simplify resource template definition with DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,10 @@ This is an example resource template that returns a text response:
 ```ruby
 class TestResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
   with_metadata do
-    {
-      name: "Test Resource Template",
-      description: "A test resource template",
-      mime_type: "text/plain",
-      uri_template: "resource://{name}"
-    }
+    name "Test Resource Template"
+    description "A test resource template"
+    mime_type "text/plain"
+    uri_template: "resource://{name}"
   end
 
   def call
@@ -182,12 +180,10 @@ This is an example resource that returns binary data:
 ```ruby
 class TestBinaryResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
   with_metadata do
-    {
-      name: "Image Search",
-      description: "Returns an image given a filename",
-      mime_type: "image/jpeg",
-      uri_template: "images://{filename}"
-    }
+    name "Image Search"
+    description "Returns an image given a filename"
+    mime_type "image/jpeg"
+    uri_template "images://{filename}"
   end
 
   def call

--- a/lib/model_context_protocol/server/resource_template.rb
+++ b/lib/model_context_protocol/server/resource_template.rb
@@ -49,12 +49,13 @@ module ModelContextProtocol
       attr_reader :name, :description, :mime_type, :uri_template
 
       def with_metadata(&block)
-        metadata = instance_eval(&block)
+        metadata_dsl = MetadataDSL.new
+        metadata_dsl.instance_eval(&block)
 
-        @name = metadata[:name]
-        @description = metadata[:description]
-        @mime_type = metadata[:mime_type]
-        @uri_template = metadata[:uri_template]
+        @name = metadata_dsl.name
+        @description = metadata_dsl.description
+        @mime_type = metadata_dsl.mime_type
+        @uri_template = metadata_dsl.uri_template
       end
 
       def inherited(subclass)
@@ -70,6 +71,28 @@ module ModelContextProtocol
 
       def metadata
         {name: @name, description: @description, mimeType: @mime_type, uriTemplate: @uri_template}
+      end
+    end
+
+    class MetadataDSL
+      def name(value = nil)
+        @name = value if value
+        @name
+      end
+
+      def description(value = nil)
+        @description = value if value
+        @description
+      end
+
+      def mime_type(value = nil)
+        @mime_type = value if value
+        @mime_type
+      end
+
+      def uri_template(value = nil)
+        @uri_template = value if value
+        @uri_template
       end
     end
   end

--- a/spec/support/resource_templates/test_binary_resource_template.rb
+++ b/spec/support/resource_templates/test_binary_resource_template.rb
@@ -1,11 +1,9 @@
 class TestBinaryResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
   with_metadata do
-    {
-      name: "Image Search",
-      description: "Returns an image given a filename",
-      mime_type: "image/jpeg",
-      uri_template: "resource://{filename}"
-    }
+    name "Image Search"
+    description "Returns an image given a filename"
+    mime_type "image/jpeg"
+    uri_template "resource://{filename}"
   end
 
   def call

--- a/spec/support/resource_templates/test_resource_template.rb
+++ b/spec/support/resource_templates/test_resource_template.rb
@@ -1,11 +1,9 @@
 class TestResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
   with_metadata do
-    {
-      name: "Test Resource Template",
-      description: "A test resource template",
-      mime_type: "text/plain",
-      uri_template: "resource://{name}"
-    }
+    name "Test Resource Template"
+    description "A test resource template"
+    mime_type "text/plain"
+    uri_template "resource://{name}"
   end
 
   def call


### PR DESCRIPTION
This PR simplifies resource template definition with a metadata DSL.
