### PR TITLE
Add functional logging

### DIFF
--- a/lib/model_context_protocol/server/mcp_logger.rb
+++ b/lib/model_context_protocol/server/mcp_logger.rb
@@ -1,0 +1,109 @@
+require "logger"
+require "forwardable"
+require "json"
+
+module ModelContextProtocol
+  class Server::MCPLogger
+    extend Forwardable
+
+    def_delegators :@internal_logger, :datetime_format=, :formatter=, :progname, :progname=
+
+    LEVEL_MAP = {
+      "debug" => Logger::DEBUG,
+      "info" => Logger::INFO,
+      "notice" => Logger::INFO,
+      "warning" => Logger::WARN,
+      "error" => Logger::ERROR,
+      "critical" => Logger::FATAL,
+      "alert" => Logger::FATAL,
+      "emergency" => Logger::UNKNOWN
+    }.freeze
+
+    REVERSE_LEVEL_MAP = {
+      Logger::DEBUG => "debug",
+      Logger::INFO => "info",
+      Logger::WARN => "warning",
+      Logger::ERROR => "error",
+      Logger::FATAL => "critical",
+      Logger::UNKNOWN => "emergency"
+    }.freeze
+
+    attr_accessor :transport
+    attr_reader :logger_name, :enabled
+
+    def initialize(logger_name: "server", level: "info", enabled: true)
+      @logger_name = logger_name
+      @enabled = enabled
+      @internal_logger = Logger.new(nil)
+      @internal_logger.level = LEVEL_MAP[level] || Logger::INFO
+      @transport = nil
+      @queued_messages = []
+    end
+
+    %i[debug info warn error fatal unknown].each do |severity|
+      define_method(severity) do |message = nil, **data, &block|
+        return true unless @enabled
+        add(Logger.const_get(severity.to_s.upcase), message, data, &block)
+      end
+    end
+
+    def add(severity, message = nil, data = {}, &block)
+      return true unless @enabled
+      return true if severity < @internal_logger.level
+
+      message = block.call if message.nil? && block_given?
+      send_notification(severity, message, data)
+      true
+    end
+
+    def level=(value)
+      @internal_logger.level = value
+    end
+
+    def level
+      @internal_logger.level
+    end
+
+    def set_mcp_level(mcp_level)
+      self.level = LEVEL_MAP[mcp_level] || Logger::INFO
+    end
+
+    def connect_transport(transport)
+      @transport = transport
+      flush_queued_messages if @enabled
+    end
+
+    private
+
+    def send_notification(severity, message, data)
+      return unless @enabled
+
+      notification_params = {
+        level: REVERSE_LEVEL_MAP[severity] || "info",
+        logger: @logger_name,
+        data: format_data(message, data)
+      }
+
+      if @transport
+        @transport.send_notification("notifications/message", notification_params)
+      else
+        @queued_messages << notification_params
+      end
+    end
+
+    def format_data(message, additional_data)
+      data = {}
+      data[:message] = message.to_s if message
+      data.merge!(additional_data) unless additional_data.empty?
+      data
+    end
+
+    def flush_queued_messages
+      return unless @transport && @enabled
+      @queued_messages.each do |params|
+        @transport.send_notification("notifications/message", params)
+      end
+      @queued_messages.clear
+    end
+  end
+end

--- a/lib/model_context_protocol/server/prompt.rb
+++ b/lib/model_context_protocol/server/prompt.rb
@@ -1,11 +1,12 @@
 module ModelContextProtocol
   class Server::Prompt
-    attr_reader :params, :context
+    attr_reader :params, :context, :logger
 
-    def initialize(params, context = {})
+    def initialize(params, logger, context = {})
       validate!(params)
       @params = params
       @context = context
+      @logger = logger
     end
 
     def call
@@ -74,8 +75,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@arguments, @arguments&.dup)
       end
 
-      def call(params, context = {})
-        new(params, context).call
+      def call(params, logger, context = {})
+        new(params, logger, context).call
       rescue ArgumentError => error
         raise ModelContextProtocol::Server::ParameterValidationError, error.message
       end

--- a/lib/model_context_protocol/server/resource.rb
+++ b/lib/model_context_protocol/server/resource.rb
@@ -1,11 +1,12 @@
 module ModelContextProtocol
   class Server::Resource
-    attr_reader :mime_type, :uri, :context
+    attr_reader :mime_type, :uri, :context, :logger
 
-    def initialize(context = {})
+    def initialize(logger, context = {})
       @mime_type = self.class.mime_type
       @uri = self.class.uri
       @context = context
+      @logger = logger
     end
 
     def call
@@ -57,8 +58,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@uri, @uri)
       end
 
-      def call(context = {})
-        new(context).call
+      def call(logger, context = {})
+        new(logger, context).call
       end
 
       def metadata

--- a/lib/model_context_protocol/server/stdio_transport.rb
+++ b/lib/model_context_protocol/server/stdio_transport.rb
@@ -12,14 +12,17 @@ module ModelContextProtocol
       end
     end
 
-    attr_reader :logger, :router
+    attr_reader :router, :configuration
 
-    def initialize(logger:, router:)
-      @logger = logger
+    def initialize(router:, configuration:)
       @router = router
+      @configuration = configuration
     end
 
     def handle
+      # Connect logger to transport
+      @configuration.logger.connect_transport(self)
+
       loop do
         line = receive_message
         break unless line
@@ -31,18 +34,17 @@ module ModelContextProtocol
           result = router.route(message)
           send_message(Response[id: message["id"], result: result.serialized])
         rescue ModelContextProtocol::Server::ParameterValidationError => validation_error
-          log("Validation error: #{validation_error.message}")
+          @configuration.logger.error("Validation error", error: validation_error.message)
           send_message(
             ErrorResponse[id: message["id"], error: {code: -32602, message: validation_error.message}]
           )
         rescue JSON::ParserError => parser_error
-          log("Parser error: #{parser_error.message}")
+          @configuration.logger.error("Parser error", error: parser_error.message)
           send_message(
             ErrorResponse[id: "", error: {code: -32700, message: parser_error.message}]
           )
         rescue => error
-          log("Internal error: #{error.message}")
-          log(error.backtrace)
+          @configuration.logger.error("Internal error", error: error.message, backtrace: error.backtrace.first(5))
           send_message(
             ErrorResponse[id: message["id"], error: {code: -32603, message: error.message}]
           )
@@ -50,11 +52,20 @@ module ModelContextProtocol
       end
     end
 
-    private
-
-    def log(output, level = :error)
-      logger.send(level.to_sym, output)
+    def send_notification(method, params)
+      notification = {
+        jsonrpc: "2.0",
+        method: method,
+        params: params
+      }
+      $stdout.puts(JSON.generate(notification))
+      $stdout.flush
+    rescue IOError => e
+      # Handle broken pipe gracefully
+      @configuration.logger.debug("Failed to send notification", error: e.message) if @configuration.logging_enabled?
     end
+
+    private
 
     def receive_message
       $stdin.gets

--- a/lib/model_context_protocol/server/stdio_transport.rb
+++ b/lib/model_context_protocol/server/stdio_transport.rb
@@ -19,7 +19,7 @@ module ModelContextProtocol
       @router = router
     end
 
-    def begin
+    def handle
       loop do
         line = receive_message
         break unless line

--- a/lib/model_context_protocol/server/streamable_http_transport.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport.rb
@@ -25,7 +25,7 @@ module ModelContextProtocol
       setup_redis_subscriber
     end
 
-    def handle_request
+    def handle
       request = @configuration.transport_options[:request]
       response = @configuration.transport_options[:response]
 

--- a/lib/model_context_protocol/server/tool.rb
+++ b/lib/model_context_protocol/server/tool.rb
@@ -2,12 +2,13 @@ require "json-schema"
 
 module ModelContextProtocol
   class Server::Tool
-    attr_reader :params, :context
+    attr_reader :params, :context, :logger
 
-    def initialize(params, context = {})
+    def initialize(params, logger, context = {})
       validate!(params)
       @params = params
       @context = context
+      @logger = logger
     end
 
     def call
@@ -91,8 +92,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@input_schema, @input_schema)
       end
 
-      def call(params, context = {})
-        new(params, context).call
+      def call(params, logger, context = {})
+        new(params, logger, context).call
       rescue JSON::Schema::ValidationError => validation_error
         raise ModelContextProtocol::Server::ParameterValidationError, validation_error.message
       rescue ModelContextProtocol::Server::ResponseArgumentsError => response_arguments_error

--- a/spec/lib/model_context_protocol/server/mcp_logger_spec.rb
+++ b/spec/lib/model_context_protocol/server/mcp_logger_spec.rb
@@ -1,0 +1,268 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::MCPLogger do
+  let(:transport) { double("transport") }
+  let(:logger) { described_class.new(logger_name: "test-logger") }
+
+  describe "#initialize" do
+    it "creates a logger with default settings" do
+      logger = described_class.new
+
+      aggregate_failures do
+        expect(logger.logger_name).to eq("server")
+        expect(logger.enabled).to be(true)
+        expect(logger.level).to eq(Logger::INFO)
+      end
+    end
+
+    it "accepts custom settings" do
+      logger = described_class.new(logger_name: "custom", level: "debug", enabled: false)
+
+      aggregate_failures do
+        expect(logger.logger_name).to eq("custom")
+        expect(logger.enabled).to be(false)
+        expect(logger.level).to eq(Logger::DEBUG)
+      end
+    end
+  end
+
+  describe "logging methods" do
+    before do
+      allow(transport).to receive(:send_notification)
+      logger.connect_transport(transport)
+    end
+
+    describe "when enabled" do
+      it "sends debug messages when level is debug" do
+        logger.level = Logger::DEBUG
+        logger.debug("test message", key: "value")
+
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message",
+          {
+            level: "debug",
+            logger: "test-logger",
+            data: {message: "test message", key: "value"}
+          }
+        )
+      end
+
+      it "sends info messages" do
+        logger.info("info message")
+
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message",
+          {
+            level: "info",
+            logger: "test-logger",
+            data: {message: "info message"}
+          }
+        )
+      end
+
+      it "sends warning messages" do
+        logger.warn("warning message", error_code: 123)
+
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message",
+          {
+            level: "warning",
+            logger: "test-logger",
+            data: {message: "warning message", error_code: 123}
+          }
+        )
+      end
+
+      it "sends error messages" do
+        logger.error("error message", backtrace: ["line1", "line2"])
+
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message",
+          {
+            level: "error",
+            logger: "test-logger",
+            data: {message: "error message", backtrace: ["line1", "line2"]}
+          }
+        )
+      end
+
+      it "sends fatal messages as critical" do
+        logger.fatal("fatal error")
+
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message",
+          {
+            level: "critical",
+            logger: "test-logger",
+            data: {message: "fatal error"}
+          }
+        )
+      end
+
+      it "sends unknown messages as emergency" do
+        logger.unknown("unknown message")
+
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message",
+          {
+            level: "emergency",
+            logger: "test-logger",
+            data: {message: "unknown message"}
+          }
+        )
+      end
+
+      it "accepts block form" do
+        logger.info { "block message" }
+
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message",
+          {
+            level: "info",
+            logger: "test-logger",
+            data: {message: "block message"}
+          }
+        )
+      end
+
+      it "handles nil message with additional data" do
+        logger.info(nil, key: "value")
+
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message",
+          {
+            level: "info",
+            logger: "test-logger",
+            data: {key: "value"}
+          }
+        )
+      end
+    end
+
+    describe "when disabled" do
+      let(:logger) { described_class.new(enabled: false) }
+
+      it "does not send notifications" do
+        logger.info("test message")
+        expect(transport).not_to have_received(:send_notification)
+      end
+    end
+  end
+
+  describe "log level filtering" do
+    before do
+      allow(transport).to receive(:send_notification)
+      logger.connect_transport(transport)
+    end
+
+    it "filters messages below the minimum level" do
+      logger.level = Logger::WARN
+
+      logger.debug("debug message")
+      logger.info("info message")
+      logger.warn("warn message")
+
+      aggregate_failures do
+        expect(transport).not_to have_received(:send_notification).with(
+          "notifications/message", hash_including(level: "debug")
+        )
+        expect(transport).not_to have_received(:send_notification).with(
+          "notifications/message", hash_including(level: "info")
+        )
+        expect(transport).to have_received(:send_notification).with(
+          "notifications/message", hash_including(level: "warning")
+        )
+      end
+    end
+  end
+
+  describe "#set_mcp_level" do
+    it "maps MCP levels to Logger levels" do
+      {
+        "debug" => Logger::DEBUG,
+        "info" => Logger::INFO,
+        "notice" => Logger::INFO,
+        "warning" => Logger::WARN,
+        "error" => Logger::ERROR,
+        "critical" => Logger::FATAL,
+        "alert" => Logger::FATAL,
+        "emergency" => Logger::UNKNOWN
+      }.each do |mcp_level, logger_level|
+        logger.set_mcp_level(mcp_level)
+        expect(logger.level).to eq(logger_level)
+      end
+    end
+
+    it "defaults to INFO for invalid levels" do
+      logger.set_mcp_level("invalid")
+      expect(logger.level).to eq(Logger::INFO)
+    end
+  end
+
+  describe "#connect_transport" do
+    it "sets the transport" do
+      logger.connect_transport(transport)
+      expect(logger.transport).to eq(transport)
+    end
+
+    context "with queued messages" do
+      before do
+        logger.info("queued message 1")
+        logger.warn("queued message 2", key: "value")
+      end
+
+      it "flushes queued messages when transport connects" do
+        allow(transport).to receive(:send_notification)
+
+        logger.connect_transport(transport)
+
+        aggregate_failures do
+          expect(transport).to have_received(:send_notification).with(
+            "notifications/message",
+            {
+              level: "info",
+              logger: "test-logger",
+              data: {message: "queued message 1"}
+            }
+          )
+
+          expect(transport).to have_received(:send_notification).with(
+            "notifications/message",
+            {
+              level: "warning",
+              logger: "test-logger",
+              data: {message: "queued message 2", key: "value"}
+            }
+          )
+        end
+      end
+
+      it "does not flush when disabled" do
+        disabled_logger = described_class.new(enabled: false)
+        disabled_logger.info("disabled message")
+
+        allow(transport).to receive(:send_notification)
+        disabled_logger.connect_transport(transport)
+
+        expect(transport).not_to have_received(:send_notification)
+      end
+    end
+  end
+
+  describe "Ruby Logger compatibility" do
+    it "delegates formatter methods" do
+      logger.formatter = Logger::Formatter.new
+
+      aggregate_failures do
+        expect(logger).to respond_to(:datetime_format=)
+        expect(logger).to respond_to(:progname)
+        expect(logger).to respond_to(:progname=)
+      end
+    end
+
+    it "supports level getter and setter" do
+      logger.level = Logger::WARN
+      expect(logger.level).to eq(Logger::WARN)
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/prompt_spec.rb
+++ b/spec/lib/model_context_protocol/server/prompt_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
 
       it "raises a ParameterValidationError" do
         expect {
-          TestPrompt.call(invalid_arguments, double("logger"))
+          logger = double("logger")
+          allow(logger).to receive(:info)
+          TestPrompt.call(invalid_arguments, logger)
         }.to raise_error(ModelContextProtocol::Server::ParameterValidationError)
       end
     end
@@ -17,12 +19,15 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
 
       it "instantiates the prompt with the provided arguments" do
         logger = double("logger")
+        allow(logger).to receive(:info)
+        allow(logger).to receive(:info)
         expect(TestPrompt).to receive(:new).with(valid_arguments, logger, {}).and_call_original
         TestPrompt.call(valid_arguments, logger)
       end
 
       it "returns the response from the instance's call method" do
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestPrompt.call(valid_arguments, logger)
         aggregate_failures do
           expect(response.messages.first[:content][:text]).to eq("My wife wants me to: clean the garage... Can you believe it?")
@@ -40,18 +45,21 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
 
     it "passes context to the instance" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       expect(TestPrompt).to receive(:new).with(valid_arguments, logger, context).and_call_original
       TestPrompt.call(valid_arguments, logger, context)
     end
 
     it "works with empty context" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       response = TestPrompt.call(valid_arguments, logger, {})
       expect(response.messages.first[:content][:text]).to eq("My wife wants me to: clean the garage... Can you believe it?")
     end
 
     it "works when context is not provided" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       response = TestPrompt.call(valid_arguments, logger)
       expect(response.messages.first[:content][:text]).to eq("My wife wants me to: clean the garage... Can you believe it?")
     end
@@ -66,13 +74,16 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
 
     context "when invalid arguments are provided" do
       it "raises an ArgumentError" do
-        expect { TestPrompt.new({foo: "bar"}, double("logger")) }.to raise_error(ArgumentError)
+        logger = double("logger")
+        allow(logger).to receive(:info)
+        expect { TestPrompt.new({foo: "bar"}, logger) }.to raise_error(ArgumentError)
       end
     end
 
     context "when valid arguments are provided" do
       it "stores the arguments" do
         logger = double("logger")
+        allow(logger).to receive(:info)
         prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, logger)
         expect(prompt.params).to eq({undesirable_activity: "clean the garage"})
       end
@@ -80,12 +91,14 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
       it "stores context when provided" do
         context = {"user_id" => "123", "session" => "abc"}
         logger = double("logger")
+        allow(logger).to receive(:info)
         prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, logger, context)
         expect(prompt.context).to eq(context)
       end
 
       it "defaults to empty hash when no context provided" do
         logger = double("logger")
+        allow(logger).to receive(:info)
         prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, logger)
         expect(prompt.context).to eq({})
       end
@@ -93,6 +106,7 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
       context "when optional arguments are provided" do
         it "stores the arguments" do
           logger = double("logger")
+          allow(logger).to receive(:info)
           prompt = TestPrompt.new({undesirable_activity: "clean the garage", tone: "whiny"}, logger)
           expect(prompt.params).to eq({undesirable_activity: "clean the garage", tone: "whiny"})
         end

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
   describe ".call" do
     it "returns the response from the instance's call method" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       response = TestResource.call(logger)
       aggregate_failures do
         expect(response.text).to eq("Nothing to see here, move along.")
@@ -25,6 +26,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
     it "passes context to the instance" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       allow(TestResource).to receive(:new).with(logger, context).and_call_original
       response = TestResource.call(logger, context)
       expect(response.text).to eq("I'm finna eat all my wife's leftovers.")
@@ -32,12 +34,14 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
     it "works with empty context" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       response = TestResource.call(logger, {})
       expect(response.text).to eq("Nothing to see here, move along.")
     end
 
     it "works when context is not provided" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       response = TestResource.call(logger)
       expect(response.text).to eq("Nothing to see here, move along.")
     end
@@ -47,18 +51,21 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     it "stores context when provided" do
       context = {user_id: "123"}
       logger = double("logger")
+      allow(logger).to receive(:info)
       resource = TestResource.new(logger, context)
       expect(resource.context).to eq(context)
     end
 
     it "defaults to empty hash when no context provided" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       resource = TestResource.new(logger)
       expect(resource.context).to eq({})
     end
 
     it "sets mime_type and uri from class metadata" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       resource = TestResource.new(logger)
       expect(resource.mime_type).to eq("text/plain")
       expect(resource.uri).to eq("file:///top-secret-plans.txt")
@@ -69,6 +76,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     describe "text response" do
       it "formats text responses correctly" do
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestResource.call(logger)
         expect(response.serialized).to eq(
           contents: [
@@ -85,6 +93,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     describe "binary response" do
       it "formats binary responses correctly" do
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestBinaryResource.call(logger)
 
         expect(response.serialized).to eq(

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -3,7 +3,8 @@ require "spec_helper"
 RSpec.describe ModelContextProtocol::Server::Resource do
   describe ".call" do
     it "returns the response from the instance's call method" do
-      response = TestResource.call
+      logger = double("logger")
+      response = TestResource.call(logger)
       aggregate_failures do
         expect(response.text).to eq("Nothing to see here, move along.")
         expect(response.serialized).to eq(
@@ -23,18 +24,21 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     let(:context) { {user_id: "123456"} }
 
     it "passes context to the instance" do
-      allow(TestResource).to receive(:new).with(context).and_call_original
-      response = TestResource.call(context)
+      logger = double("logger")
+      allow(TestResource).to receive(:new).with(logger, context).and_call_original
+      response = TestResource.call(logger, context)
       expect(response.text).to eq("I'm finna eat all my wife's leftovers.")
     end
 
     it "works with empty context" do
-      response = TestResource.call({})
+      logger = double("logger")
+      response = TestResource.call(logger, {})
       expect(response.text).to eq("Nothing to see here, move along.")
     end
 
     it "works when context is not provided" do
-      response = TestResource.call
+      logger = double("logger")
+      response = TestResource.call(logger)
       expect(response.text).to eq("Nothing to see here, move along.")
     end
   end
@@ -42,17 +46,20 @@ RSpec.describe ModelContextProtocol::Server::Resource do
   describe "#initialize" do
     it "stores context when provided" do
       context = {user_id: "123"}
-      resource = TestResource.new(context)
+      logger = double("logger")
+      resource = TestResource.new(logger, context)
       expect(resource.context).to eq(context)
     end
 
     it "defaults to empty hash when no context provided" do
-      resource = TestResource.new
+      logger = double("logger")
+      resource = TestResource.new(logger)
       expect(resource.context).to eq({})
     end
 
     it "sets mime_type and uri from class metadata" do
-      resource = TestResource.new
+      logger = double("logger")
+      resource = TestResource.new(logger)
       expect(resource.mime_type).to eq("text/plain")
       expect(resource.uri).to eq("file:///top-secret-plans.txt")
     end
@@ -61,7 +68,8 @@ RSpec.describe ModelContextProtocol::Server::Resource do
   describe "responses" do
     describe "text response" do
       it "formats text responses correctly" do
-        response = TestResource.call
+        logger = double("logger")
+        response = TestResource.call(logger)
         expect(response.serialized).to eq(
           contents: [
             {
@@ -76,7 +84,8 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
     describe "binary response" do
       it "formats binary responses correctly" do
-        response = TestBinaryResource.call
+        logger = double("logger")
+        response = TestBinaryResource.call(logger)
 
         expect(response.serialized).to eq(
           contents: [

--- a/spec/lib/model_context_protocol/server/stdio_transport_spec.rb
+++ b/spec/lib/model_context_protocol/server/stdio_transport_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
     $stdout = @original_stdout
   end
 
-  describe "#begin" do
+  describe "#handle" do
     context "with a valid request" do
       let(:request) { {"jsonrpc" => "2.0", "id" => 1, "method" => "test_method"} }
 
@@ -47,7 +47,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
 
       it "processes the request and sends a response" do
         begin
-          transport.begin
+          transport.handle
         rescue EOFError
           # Expected to raise EOFError when stdin is exhausted
         end
@@ -72,7 +72,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
 
       it "does not process notifications" do
         begin
-          transport.begin
+          transport.handle
         rescue EOFError
           # Expected
         end
@@ -99,7 +99,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
         allow(logger).to receive(:error)
 
         begin
-          transport.begin
+          transport.handle
         rescue EOFError
           # Expected
         end
@@ -131,7 +131,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
         allow(logger).to receive(:error)
 
         begin
-          transport.begin
+          transport.handle
         rescue EOFError
           # Expected
         end
@@ -161,7 +161,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
         allow(logger).to receive(:error)
 
         begin
-          transport.begin
+          transport.handle
         rescue EOFError
           # Expected
         end
@@ -197,7 +197,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
 
       it "processes all requests in sequence" do
         begin
-          transport.begin
+          transport.handle
         rescue EOFError
           # Expected
         end

--- a/spec/lib/model_context_protocol/server/stdio_transport_spec.rb
+++ b/spec/lib/model_context_protocol/server/stdio_transport_spec.rb
@@ -7,10 +7,11 @@ TestResponse = Data.define(:text) do
 end
 
 RSpec.describe ModelContextProtocol::Server::StdioTransport do
-  subject(:transport) { described_class.new(logger: logger, router: router) }
+  subject(:transport) { described_class.new(router: router, configuration: configuration) }
 
-  let(:logger) { Logger.new(StringIO.new) }
   let(:router) { ModelContextProtocol::Server::Router.new }
+  let(:configuration) { ModelContextProtocol::Server::Configuration.new }
+  let(:mcp_logger) { configuration.logger }
 
   before do
     @original_stdin = $stdin
@@ -96,7 +97,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
       end
 
       it "sends an error response" do
-        allow(logger).to receive(:error)
+        allow(mcp_logger).to receive(:error)
 
         begin
           transport.handle
@@ -114,7 +115,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
           expect(error_response).to include("error")
           expect(error_response["error"]["code"]).to eq(-32700)
           expect(error_response["error"]["message"]).to include("unexpected token")
-          expect(logger).to have_received(:error).with(/Parser error/)
+          expect(mcp_logger).to have_received(:error).with("Parser error", error: String)
         end
       end
     end
@@ -128,7 +129,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
       end
 
       it "sends a validation error response" do
-        allow(logger).to receive(:error)
+        allow(mcp_logger).to receive(:error)
 
         begin
           transport.handle
@@ -144,7 +145,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
           expect(response_json).to include("error")
           expect(response_json["error"]["code"]).to eq(-32602)
           expect(response_json["error"]["message"]).to eq("Invalid parameters")
-          expect(logger).to have_received(:error).with(/Validation error: Invalid parameters/)
+          expect(mcp_logger).to have_received(:error).with("Validation error", error: "Invalid parameters")
         end
       end
     end
@@ -158,7 +159,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
       end
 
       it "sends an internal error response" do
-        allow(logger).to receive(:error)
+        allow(mcp_logger).to receive(:error)
 
         begin
           transport.handle
@@ -174,8 +175,9 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
           expect(response_json).to include("error")
           expect(response_json["error"]["code"]).to eq(-32603)
           expect(response_json["error"]["message"]).to eq("Something went wrong")
-          expect(logger).to have_received(:error).with(/Internal error: Something went wrong/)
-          expect(logger).to have_received(:error).with(kind_of(Array)) # backtrace
+          expect(mcp_logger).to have_received(:error).with("Internal error",
+            error: "Something went wrong",
+            backtrace: kind_of(Array))
         end
       end
     end
@@ -212,6 +214,68 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
           expect(responses[0]["result"]).to eq({"text" => "method1 response"})
           expect(responses[1]["id"]).to eq(2)
           expect(responses[1]["result"]).to eq({"text" => "method2 response"})
+        end
+      end
+    end
+  end
+
+  describe "MCP logging integration" do
+    it "connects the logger to the transport when handle starts" do
+      expect(mcp_logger).to receive(:connect_transport).with(transport)
+
+      begin
+        transport.handle
+      rescue EOFError
+        # Expected when stdin is empty
+      end
+    end
+
+    describe "#send_notification" do
+      before do
+        # Connect logger so notifications can be sent
+        mcp_logger.connect_transport(transport)
+      end
+
+      it "sends MCP notifications to stdout" do
+        transport.send_notification("notifications/message", {
+          level: "info",
+          logger: "test",
+          data: {message: "test notification"}
+        })
+
+        $stdout.rewind
+        output = $stdout.read
+        notification = JSON.parse(output)
+
+        aggregate_failures do
+          expect(notification["jsonrpc"]).to eq("2.0")
+          expect(notification["method"]).to eq("notifications/message")
+          expect(notification["params"]["level"]).to eq("info")
+          expect(notification["params"]["logger"]).to eq("test")
+          expect(notification["params"]["data"]["message"]).to eq("test notification")
+        end
+      end
+
+      it "handles broken pipe gracefully" do
+        allow($stdout).to receive(:puts).and_raise(IOError, "broken pipe")
+        allow($stdout).to receive(:flush)
+
+        expect {
+          transport.send_notification("notifications/message", {level: "error", data: {}})
+        }.not_to raise_error
+      end
+
+      context "when logging is disabled" do
+        before do
+          configuration.logging_enabled = false
+        end
+
+        it "does not log debug messages about failed notifications when logging disabled" do
+          allow($stdout).to receive(:puts).and_raise(IOError, "broken pipe")
+          allow($stdout).to receive(:flush)
+          expect(mcp_logger).not_to receive(:debug)
+
+          transport.send_notification("notifications/message", {level: "info", data: {}})
         end
       end
     end

--- a/spec/lib/model_context_protocol/server/tool_spec.rb
+++ b/spec/lib/model_context_protocol/server/tool_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
 
       it "raises a ParameterValidationError" do
         expect {
-          TestToolWithTextResponse.call(invalid_arguments)
+          TestToolWithTextResponse.call(invalid_arguments, double("logger"))
         }.to raise_error(ModelContextProtocol::Server::ParameterValidationError)
       end
     end
@@ -16,12 +16,14 @@ RSpec.describe ModelContextProtocol::Server::Tool do
       let(:valid_arguments) { {number: "21"} }
 
       it "instantiates the tool with the provided arguments" do
-        expect(TestToolWithTextResponse).to receive(:new).with(valid_arguments, {}).and_call_original
-        TestToolWithTextResponse.call(valid_arguments)
+        logger = double("logger")
+        expect(TestToolWithTextResponse).to receive(:new).with(valid_arguments, logger, {}).and_call_original
+        TestToolWithTextResponse.call(valid_arguments, logger)
       end
 
       it "returns the response from the instance's call method" do
-        response = TestToolWithTextResponse.call(valid_arguments)
+        logger = double("logger")
+        response = TestToolWithTextResponse.call(valid_arguments, logger)
         aggregate_failures do
           expect(response.text).to eq("21 doubled is 42")
           expect(response.serialized).to eq(
@@ -42,7 +44,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
         end
 
         it "returns an error response" do
-          response = TestToolWithTextResponse.call(valid_arguments)
+          logger = double("logger")
+          response = TestToolWithTextResponse.call(valid_arguments, logger)
           aggregate_failures do
             expect(response.text).to eq("Test error")
             expect(response.serialized).to eq(
@@ -66,22 +69,25 @@ RSpec.describe ModelContextProtocol::Server::Tool do
         TestToolWithTextResponse.input_schema,
         {"text" => "Hello, world!"}
       )
-      TestToolWithTextResponse.new({"text" => "Hello, world!"})
+      TestToolWithTextResponse.new({"text" => "Hello, world!"}, double("logger"))
     end
 
     it "stores the arguments" do
-      tool = TestToolWithTextResponse.new({number: "42"})
+      logger = double("logger")
+      tool = TestToolWithTextResponse.new({number: "42"}, logger)
       expect(tool.params).to eq({number: "42"})
     end
 
     it "stores context when provided" do
       context = {"user_id" => "123", "session" => "abc"}
-      tool = TestToolWithTextResponse.new({"number" => "42"}, context)
+      logger = double("logger")
+      tool = TestToolWithTextResponse.new({"number" => "42"}, logger, context)
       expect(tool.context).to eq(context)
     end
 
     it "defaults to empty hash when no context provided" do
-      tool = TestToolWithTextResponse.new({number: "42"})
+      logger = double("logger")
+      tool = TestToolWithTextResponse.new({number: "42"}, logger)
       expect(tool.context).to eq({})
     end
   end
@@ -91,21 +97,24 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     let(:context) { {user_id: "123456"} }
 
     it "passes context to the instance" do
-      allow(TestToolWithTextResponse).to receive(:new).with(valid_arguments, context).and_call_original
-      response = TestToolWithTextResponse.call(valid_arguments, context)
+      logger = double("logger")
+      allow(TestToolWithTextResponse).to receive(:new).with(valid_arguments, logger, context).and_call_original
+      response = TestToolWithTextResponse.call(valid_arguments, logger, context)
       aggregate_failures do
-        expect(TestToolWithTextResponse).to have_received(:new).with(valid_arguments, context)
+        expect(TestToolWithTextResponse).to have_received(:new).with(valid_arguments, logger, context)
         expect(response.text).to eq("User 123456, 21 doubled is 42")
       end
     end
 
     it "works with empty context" do
-      response = TestToolWithTextResponse.call(valid_arguments, {})
+      logger = double("logger")
+      response = TestToolWithTextResponse.call(valid_arguments, logger, {})
       expect(response.text).to eq("21 doubled is 42")
     end
 
     it "works when context is not provided" do
-      response = TestToolWithTextResponse.call(valid_arguments)
+      logger = double("logger")
+      response = TestToolWithTextResponse.call(valid_arguments, logger)
       expect(response.text).to eq("21 doubled is 42")
     end
   end
@@ -114,7 +123,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     describe "text response" do
       it "formats text response correctly" do
         arguments = {number: "21"}
-        response = TestToolWithTextResponse.call(arguments)
+        logger = double("logger")
+        response = TestToolWithTextResponse.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
             {
@@ -130,7 +140,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     describe "image response" do
       it "formats image responses correctly" do
         arguments = {chart_type: "bar", format: "jpg"}
-        response = TestToolWithImageResponse.call(arguments)
+        logger = double("logger")
+        response = TestToolWithImageResponse.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
             {
@@ -145,7 +156,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
 
       it "defaults to PNG mime type" do
         arguments = {chart_type: "bar"}
-        response = TestToolWithImageResponseDefaultMimeType.call(arguments)
+        logger = double("logger")
+        response = TestToolWithImageResponseDefaultMimeType.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
             {
@@ -162,7 +174,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     describe "resource response" do
       it "formats resource responses correctly" do
         arguments = {title: "Foobar"}
-        response = TestToolWithResourceResponse.call(arguments)
+        logger = double("logger")
+        response = TestToolWithResourceResponse.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
             type: "resource",
@@ -178,7 +191,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
 
       it "defaults to text/plain mime type" do
         arguments = {title: "foobar", content: "baz"}
-        response = TestToolWithResourceResponseDefaultMimeType.call(arguments)
+        logger = double("logger")
+        response = TestToolWithResourceResponseDefaultMimeType.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
             type: "resource",
@@ -196,7 +210,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     describe "tool error response" do
       it "formats error responses correctly" do
         arguments = {api_endpoint: "http://example.com", method: "GET"}
-        response = TestToolWithToolErrorResponse.call(arguments)
+        logger = double("logger")
+        response = TestToolWithToolErrorResponse.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
             {

--- a/spec/lib/model_context_protocol/server/tool_spec.rb
+++ b/spec/lib/model_context_protocol/server/tool_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe ModelContextProtocol::Server::Tool do
 
       it "raises a ParameterValidationError" do
         expect {
-          TestToolWithTextResponse.call(invalid_arguments, double("logger"))
+          logger = double("logger")
+          allow(logger).to receive(:info)
+          TestToolWithTextResponse.call(invalid_arguments, logger)
         }.to raise_error(ModelContextProtocol::Server::ParameterValidationError)
       end
     end
@@ -17,12 +19,14 @@ RSpec.describe ModelContextProtocol::Server::Tool do
 
       it "instantiates the tool with the provided arguments" do
         logger = double("logger")
+        allow(logger).to receive(:info)
         expect(TestToolWithTextResponse).to receive(:new).with(valid_arguments, logger, {}).and_call_original
         TestToolWithTextResponse.call(valid_arguments, logger)
       end
 
       it "returns the response from the instance's call method" do
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestToolWithTextResponse.call(valid_arguments, logger)
         aggregate_failures do
           expect(response.text).to eq("21 doubled is 42")
@@ -45,6 +49,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
 
         it "returns an error response" do
           logger = double("logger")
+          allow(logger).to receive(:info)
           response = TestToolWithTextResponse.call(valid_arguments, logger)
           aggregate_failures do
             expect(response.text).to eq("Test error")
@@ -69,11 +74,14 @@ RSpec.describe ModelContextProtocol::Server::Tool do
         TestToolWithTextResponse.input_schema,
         {"text" => "Hello, world!"}
       )
-      TestToolWithTextResponse.new({"text" => "Hello, world!"}, double("logger"))
+      logger = double("logger")
+      allow(logger).to receive(:info)
+      TestToolWithTextResponse.new({"text" => "Hello, world!"}, logger)
     end
 
     it "stores the arguments" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       tool = TestToolWithTextResponse.new({number: "42"}, logger)
       expect(tool.params).to eq({number: "42"})
     end
@@ -81,12 +89,14 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     it "stores context when provided" do
       context = {"user_id" => "123", "session" => "abc"}
       logger = double("logger")
+      allow(logger).to receive(:info)
       tool = TestToolWithTextResponse.new({"number" => "42"}, logger, context)
       expect(tool.context).to eq(context)
     end
 
     it "defaults to empty hash when no context provided" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       tool = TestToolWithTextResponse.new({number: "42"}, logger)
       expect(tool.context).to eq({})
     end
@@ -98,6 +108,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
 
     it "passes context to the instance" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       allow(TestToolWithTextResponse).to receive(:new).with(valid_arguments, logger, context).and_call_original
       response = TestToolWithTextResponse.call(valid_arguments, logger, context)
       aggregate_failures do
@@ -108,12 +119,14 @@ RSpec.describe ModelContextProtocol::Server::Tool do
 
     it "works with empty context" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       response = TestToolWithTextResponse.call(valid_arguments, logger, {})
       expect(response.text).to eq("21 doubled is 42")
     end
 
     it "works when context is not provided" do
       logger = double("logger")
+      allow(logger).to receive(:info)
       response = TestToolWithTextResponse.call(valid_arguments, logger)
       expect(response.text).to eq("21 doubled is 42")
     end
@@ -124,6 +137,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
       it "formats text response correctly" do
         arguments = {number: "21"}
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestToolWithTextResponse.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
@@ -141,6 +155,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
       it "formats image responses correctly" do
         arguments = {chart_type: "bar", format: "jpg"}
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestToolWithImageResponse.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
@@ -157,6 +172,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
       it "defaults to PNG mime type" do
         arguments = {chart_type: "bar"}
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestToolWithImageResponseDefaultMimeType.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
@@ -175,6 +191,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
       it "formats resource responses correctly" do
         arguments = {title: "Foobar"}
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestToolWithResourceResponse.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
@@ -192,6 +209,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
       it "defaults to text/plain mime type" do
         arguments = {title: "foobar", content: "baz"}
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestToolWithResourceResponseDefaultMimeType.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [
@@ -211,6 +229,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
       it "formats error responses correctly" do
         arguments = {api_endpoint: "http://example.com", method: "GET"}
         logger = double("logger")
+        allow(logger).to receive(:info)
         response = TestToolWithToolErrorResponse.call(arguments, logger)
         expect(response.serialized).to eq(
           content: [

--- a/spec/support/prompts/test_prompt.rb
+++ b/spec/support/prompts/test_prompt.rb
@@ -25,6 +25,7 @@ class TestPrompt < ModelContextProtocol::Server::Prompt
   end
 
   def call
+    logger.info("Brainstorming excuses...")
     messages = [
       {
         role: "user",

--- a/spec/support/resources/test_resource.rb
+++ b/spec/support/resources/test_resource.rb
@@ -8,6 +8,7 @@ class TestResource < ModelContextProtocol::Server::Resource
 
   def call
     unless authorized?(context[:user_id])
+      logger.info("This fool thinks he can get my top secret plans...")
       return respond_with :text, text: "Nothing to see here, move along."
     end
 

--- a/spec/support/tools/test_tool_with_text_response.rb
+++ b/spec/support/tools/test_tool_with_text_response.rb
@@ -18,6 +18,7 @@ class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
   def call
     user_id = context[:user_id]
     number = params[:number].to_i
+    logger.info("Silly user doesn't know how to double a number")
     calculation = number * 2
     salutation = user_id ? "User #{user_id}, " : ""
     respond_with :text, text: salutation << "#{number} doubled is #{calculation}"

--- a/tasks/templates/dev.erb
+++ b/tasks/templates/dev.erb
@@ -9,7 +9,7 @@ Dir[File.join(__dir__, "../spec/support/**/*.rb")].each { |file| require file }
 server = ModelContextProtocol::Server.new do |config|
   config.name = "MCP Development Server"
   config.version = "1.0.0"
-  config.enable_log = true
+  config.logging_enabled = true
 
   config.set_environment_variable("MCP_ENV", "development")
 


### PR DESCRIPTION
This PR adds functional logging that is compliant with the spec.

- **Implement MCP logger**
- **Update logging configuration option**
- **Standardize transport handle method name**
- **Add logging support to transports**
- **Add logging support to prompts, tools, and resources**
- **Add logging support to the server**
- **Update test classes and dev executable template**
- **Update documentation**
