### PR TITLE
Add support for MCP server title and instructions

### DIFF
--- a/lib/model_context_protocol/server/configuration.rb
+++ b/lib/model_context_protocol/server/configuration.rb
@@ -8,6 +8,12 @@ module ModelContextProtocol
     # Raised when configured with invalid version.
     class InvalidServerVersionError < StandardError; end
 
+    # Raised when configured with invalid title.
+    class InvalidServerTitleError < StandardError; end
+
+    # Raised when configured with invalid instructions.
+    class InvalidServerInstructionsError < StandardError; end
+
     # Raised when configured with invalid registry.
     class InvalidRegistryError < StandardError; end
 
@@ -26,7 +32,7 @@ module ModelContextProtocol
     # Valid MCP log levels per the specification
     VALID_LOG_LEVELS = %w[debug info notice warning error critical alert emergency].freeze
 
-    attr_accessor :name, :registry, :version, :transport, :pagination
+    attr_accessor :name, :registry, :version, :transport, :pagination, :title, :instructions
     attr_reader :logger
 
     def initialize
@@ -119,6 +125,8 @@ module ModelContextProtocol
       raise InvalidServerVersionError unless valid_version?
       validate_transport!
       validate_pagination!
+      validate_title!
+      validate_instructions!
 
       validate_environment_variables!
     end
@@ -220,6 +228,20 @@ module ModelContextProtocol
       if opts[:cursor_ttl] && opts[:cursor_ttl] <= 0
         raise InvalidPaginationError, "Invalid pagination cursor_ttl: must be positive or nil"
       end
+    end
+
+    def validate_title!
+      return if title.nil?
+      return if title.is_a?(String)
+
+      raise InvalidServerTitleError, "Server title must be a string"
+    end
+
+    def validate_instructions!
+      return if instructions.nil?
+      return if instructions.is_a?(String)
+
+      raise InvalidServerInstructionsError, "Server instructions must be a string"
     end
   end
 end

--- a/spec/lib/model_context_protocol/server/configuration_spec.rb
+++ b/spec/lib/model_context_protocol/server/configuration_spec.rb
@@ -401,6 +401,112 @@ RSpec.describe ModelContextProtocol::Server::Configuration do
         expect { configuration.validate! }.not_to raise_error
       end
     end
+
+    context "with title" do
+      before do
+        configuration.name = "test-server"
+        configuration.registry = registry
+        configuration.version = "1.0.0"
+      end
+
+      it "validates successfully when title is a string" do
+        configuration.title = "My Test Server"
+
+        expect { configuration.validate! }.not_to raise_error
+      end
+
+      it "validates successfully when title is nil" do
+        configuration.title = nil
+
+        expect { configuration.validate! }.not_to raise_error
+      end
+
+      it "raises error when title is not a string" do
+        configuration.title = 123
+
+        expect { configuration.validate! }.to raise_error(
+          described_class::InvalidServerTitleError,
+          "Server title must be a string"
+        )
+      end
+
+      it "raises error when title is an array" do
+        configuration.title = ["not", "a", "string"]
+
+        expect { configuration.validate! }.to raise_error(
+          described_class::InvalidServerTitleError,
+          "Server title must be a string"
+        )
+      end
+
+      it "raises error when title is a hash" do
+        configuration.title = {name: "test"}
+
+        expect { configuration.validate! }.to raise_error(
+          described_class::InvalidServerTitleError,
+          "Server title must be a string"
+        )
+      end
+    end
+
+    context "with instructions" do
+      before do
+        configuration.name = "test-server"
+        configuration.registry = registry
+        configuration.version = "1.0.0"
+      end
+
+      it "validates successfully when instructions is a string" do
+        configuration.instructions = "Use this server for testing."
+
+        expect { configuration.validate! }.not_to raise_error
+      end
+
+      it "validates successfully when instructions is nil" do
+        configuration.instructions = nil
+
+        expect { configuration.validate! }.not_to raise_error
+      end
+
+      it "validates successfully when instructions is a multi-line string" do
+        configuration.instructions = <<~INSTRUCTIONS
+          This server provides test capabilities.
+          
+          Key features:
+          - Feature one
+          - Feature two
+        INSTRUCTIONS
+
+        expect { configuration.validate! }.not_to raise_error
+      end
+
+      it "raises error when instructions is not a string" do
+        configuration.instructions = []
+
+        expect { configuration.validate! }.to raise_error(
+          described_class::InvalidServerInstructionsError,
+          "Server instructions must be a string"
+        )
+      end
+
+      it "raises error when instructions is a number" do
+        configuration.instructions = 456
+
+        expect { configuration.validate! }.to raise_error(
+          described_class::InvalidServerInstructionsError,
+          "Server instructions must be a string"
+        )
+      end
+
+      it "raises error when instructions is a hash" do
+        configuration.instructions = {message: "test instructions"}
+
+        expect { configuration.validate! }.to raise_error(
+          described_class::InvalidServerInstructionsError,
+          "Server instructions must be a string"
+        )
+      end
+    end
   end
 
   describe "environment variables" do


### PR DESCRIPTION
This PR adds support for title and instructions in the initialize response.

- **Add title and instructions to configuration**
- **Add title and instructions to server**
- **Update README**
