### PR TITLE
Implement content data objects and helpers

### DIFF
--- a/lib/model_context_protocol/server/content.rb
+++ b/lib/model_context_protocol/server/content.rb
@@ -1,0 +1,326 @@
+require "json-schema"
+
+module ModelContextProtocol
+  module Server::Content
+    class ContentValidationError < StandardError; end
+
+    Text = Data.define(:meta, :annotations, :text) do
+      def serialized
+        serialized_data = {
+          _meta: meta,
+          annotations:,
+          text:,
+          type: "text"
+        }.compact
+
+        validation_errors = JSON::Validator.fully_validate(schema, serialized_data)
+        if validation_errors.empty?
+          serialized_data
+        else
+          raise ContentValidationError, validation_errors.join(", ")
+        end
+      end
+
+      private
+
+      def schema
+        {
+          type: "object",
+          required: ["type", "text"],
+          properties: {
+            _meta: {
+              type: "object",
+              description: "Contains metadata about the content block"
+            },
+            annotations: {
+              type: "object",
+              description: "Optional metadata about the purpose and use of the content block"
+            },
+            text: {
+              type: "string",
+              description: "The text content of the content block"
+            },
+            type: {
+              type: "string",
+              description: "The type of content block",
+              pattern: "^text$"
+            }
+          }
+        }
+      end
+    end
+
+    Image = Data.define(:meta, :annotations, :data, :mime_type) do
+      def serialized
+        serialized_data = {
+          _meta: meta,
+          annotations:,
+          data:,
+          mimeType: mime_type,
+          type: "image"
+        }.compact
+
+        validation_errors = JSON::Validator.fully_validate(schema, serialized_data)
+        if validation_errors.empty?
+          serialized_data
+        else
+          raise ContentValidationError, validation_errors.join(", ")
+        end
+      end
+
+      private
+
+      def schema
+        {
+          type: "object",
+          required: ["data", "mimeType", "type"],
+          properties: {
+            _meta: {
+              type: "object",
+              description: "Contains metadata about the content block"
+            },
+            annotations: {
+              type: "object",
+              description: "Optional metadata about the purpose and use of the content block"
+            },
+            data: {
+              type: "string",
+              description: "The base64 encoded image data"
+            },
+            mimeType: {
+              type: "string",
+              description: "The mime type associated with the image data"
+            },
+            type: {
+              type: "string",
+              description: "The type of content block",
+              pattern: "^image$"
+            }
+          }
+        }
+      end
+    end
+
+    Audio = Data.define(:meta, :annotations, :data, :mime_type) do
+      def serialized
+        serialized_data = {
+          _meta: meta,
+          annotations:,
+          data:,
+          mimeType: mime_type,
+          type: "audio"
+        }.compact
+
+        validation_errors = JSON::Validator.fully_validate(schema, serialized_data)
+        if validation_errors.empty?
+          serialized_data
+        else
+          raise ContentValidationError, validation_errors.join(", ")
+        end
+      end
+
+      private
+
+      def schema
+        {
+          type: "object",
+          required: ["data", "mimeType", "type"],
+          properties: {
+            _meta: {
+              type: "object",
+              description: "Contains metadata about the content block"
+            },
+            annotations: {
+              type: "object",
+              description: "Optional metadata about the purpose and use of the content block"
+            },
+            data: {
+              type: "string",
+              description: "The base64 encoded image data"
+            },
+            mimeType: {
+              type: "string",
+              description: "The mime type associated with the image data"
+            },
+            type: {
+              type: "string",
+              description: "The type of content block",
+              pattern: "^audio$"
+            }
+          }
+        }
+      end
+    end
+
+    EmbeddedResource = Data.define(:meta, :annotations, :resource) do
+      def serialized
+        serialized_data = {
+          _meta: meta,
+          annotations:,
+          resource: resource&.serialized,
+          type: "resource"
+        }.compact
+
+        validation_errors = JSON::Validator.fully_validate(schema, serialized_data)
+        if validation_errors.empty?
+          serialized_data
+        else
+          raise ContentValidationError, validation_errors.join(", ")
+        end
+      end
+
+      private
+
+      def schema
+        {
+          type: "object",
+          required: ["type", "resource"],
+          properties: {
+            _meta: {
+              type: "object",
+              description: "Contains metadata about the content block"
+            },
+            annotations: {
+              type: "object",
+              description: "Optional metadata about the purpose and use of the content block"
+            },
+            resource: {
+              type: "object",
+              description: "The resource embedded in the content block"
+            },
+            type: {
+              type: "string",
+              description: "The type of content block",
+              pattern: "^resource$"
+            }
+          }
+        }
+      end
+    end
+
+    ResourceLink = Data.define(:meta, :annotations, :description, :mime_type, :name, :size, :title, :uri) do
+      def serialized
+        serialized_data = {
+          _meta: meta,
+          annotations:,
+          description:,
+          mimeType: mime_type,
+          name:,
+          size:,
+          title:,
+          type: "resource_link",
+          uri:
+        }.compact
+
+        validation_errors = JSON::Validator.fully_validate(schema, serialized_data)
+        if validation_errors.empty?
+          serialized_data
+        else
+          raise ContentValidationError, validation_errors.join(", ")
+        end
+      end
+
+      private
+
+      def schema
+        {
+          type: "object",
+          required: ["name", "type", "uri"],
+          properties: {
+            _meta: {
+              type: "object",
+              description: "Contains metadata about the content block"
+            },
+            annotations: {
+              type: "object",
+              description: "Optional metadata about the purpose and use of the content block"
+            },
+            description: {
+              type: "string",
+              description: "A description of what this resource represents"
+            },
+            mimeType: {
+              type: "string",
+              description: "The mime type of the resource in bytes (if known)"
+            },
+            name: {
+              type: "string",
+              description: "Name of the resource link, intended for programmatic use"
+            },
+            size: {
+              type: "number",
+              description: "The size of the raw resource content in bytes (if known)"
+            },
+            title: {
+              type: "string",
+              description: "Name of the resource link, intended for display purposes"
+            },
+            type: {
+              type: "string",
+              description: "The type of content block",
+              pattern: "^resource_link$"
+            },
+            uri: {
+              type: "string",
+              description: "The URI of this resource"
+            }
+          }
+        }
+      end
+    end
+
+    Annotations = Data.define(:audience, :last_modified, :priority) do
+      def serialized
+        serialized_data = {audience:, lastModified: last_modified, priority:}.compact
+
+        validation_errors = JSON::Validator.fully_validate(schema, serialized_data)
+        unless validation_errors.empty?
+          raise ContentValidationError, validation_errors.join(", ")
+        end
+
+        serialized_data.empty? ? nil : serialized_data
+      end
+
+      private
+
+      def schema
+        {
+          type: "object",
+          description: "Optional metadata about the purpose and use of the content block",
+          properties: {
+            audience: {
+              oneOf: [
+                {
+                  type: "string",
+                  enum: ["user", "assistant"]
+                },
+                {
+                  type: "array",
+                  items: {
+                    type: "string",
+                    enum: ["user", "assistant"]
+                  },
+                  minItems: 1,
+                  maxItems: 2,
+                  uniqueItems: true
+                }
+              ],
+              description: "The intended audience for the content block"
+            },
+            lastModified: {
+              type: "string",
+              pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?Z$",
+              description: "The date the content was last modified (in ISO 8601 format)"
+            },
+            priority: {
+              type: "number",
+              description: "The weight of importance the audience should place on the contents of the content block",
+              minimum: 0.0,
+              maximum: 1.0
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/model_context_protocol/server/content_helpers.rb
+++ b/lib/model_context_protocol/server/content_helpers.rb
@@ -1,0 +1,80 @@
+module ModelContextProtocol
+  module Server::ContentHelpers
+    def text_content(text:, meta: nil, annotations: {})
+      serialized_annotations = ModelContextProtocol::Server::Content::Annotations[
+        audience: annotations[:audience],
+        last_modified: annotations[:last_modified],
+        priority: annotations[:priority]
+      ].serialized
+
+      ModelContextProtocol::Server::Content::Text[
+        meta:,
+        annotations: serialized_annotations,
+        text:
+      ]
+    end
+
+    def image_content(data:, mime_type:, meta: nil, annotations: {})
+      serialized_annotations = ModelContextProtocol::Server::Content::Annotations[
+        audience: annotations[:audience],
+        last_modified: annotations[:last_modified],
+        priority: annotations[:priority]
+      ].serialized
+
+      ModelContextProtocol::Server::Content::Image[
+        meta:,
+        annotations: serialized_annotations,
+        data:,
+        mime_type:
+      ]
+    end
+
+    def audio_content(data:, mime_type:, meta: nil, annotations: {})
+      serialized_annotations = ModelContextProtocol::Server::Content::Annotations[
+        audience: annotations[:audience],
+        last_modified: annotations[:last_modified],
+        priority: annotations[:priority]
+      ].serialized
+
+      ModelContextProtocol::Server::Content::Audio[
+        meta:,
+        annotations: serialized_annotations,
+        data:,
+        mime_type:
+      ]
+    end
+
+    def embedded_resource_content(resource:, meta: nil, annotations: {})
+      serialized_annotations = ModelContextProtocol::Server::Content::Annotations[
+        audience: annotations[:audience],
+        last_modified: annotations[:last_modified],
+        priority: annotations[:priority]
+      ].serialized
+
+      ModelContextProtocol::Server::Content::EmbeddedResource[
+        meta:,
+        annotations: serialized_annotations,
+        resource:
+      ]
+    end
+
+    def resource_link(name:, uri:, meta: nil, annotations: {}, description: nil, mime_type: nil, size: nil, title: nil)
+      serialized_annotations = ModelContextProtocol::Server::Content::Annotations[
+        audience: annotations[:audience],
+        last_modified: annotations[:last_modified],
+        priority: annotations[:priority]
+      ].serialized
+
+      ModelContextProtocol::Server::Content::ResourceLink[
+        meta:,
+        annotations: serialized_annotations,
+        description:,
+        mime_type:,
+        name:,
+        size:,
+        title:,
+        uri:
+      ].serialized
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/content_helpers_spec.rb
+++ b/spec/lib/model_context_protocol/server/content_helpers_spec.rb
@@ -1,0 +1,335 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::ContentHelpers do
+  # Create a test class that includes the module
+  let(:test_class) do
+    Class.new do
+      include ModelContextProtocol::Server::ContentHelpers
+    end
+  end
+
+  let(:helper) { test_class.new }
+
+  describe "#text_content" do
+    context "with valid data" do
+      it "returns a Text content object with required parameters" do
+        result = helper.text_content(text: "Hello world")
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Text)
+        expect(result.text).to eq("Hello world")
+        expect(result.meta).to be_nil
+        expect(result.annotations).to be_nil
+      end
+
+      it "returns a Text content object with meta" do
+        result = helper.text_content(text: "Hello world", meta: {source: "test"})
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Text)
+        expect(result.text).to eq("Hello world")
+        expect(result.meta).to eq({source: "test"})
+        expect(result.annotations).to be_nil
+      end
+
+      it "returns a Text content object with annotations" do
+        annotations = {audience: "user", priority: 0.8}
+        result = helper.text_content(text: "Hello world", annotations: annotations)
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Text)
+        expect(result.text).to eq("Hello world")
+        expect(result.meta).to be_nil
+        expect(result.annotations).to eq({audience: "user", priority: 0.8})
+      end
+
+      it "returns a Text content object with all parameters" do
+        annotations = {audience: ["user", "assistant"], last_modified: "2025-01-12T15:00:58Z", priority: 1.0}
+        result = helper.text_content(
+          text: "Hello world",
+          meta: {id: 123},
+          annotations: annotations
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Text)
+        expect(result.text).to eq("Hello world")
+        expect(result.meta).to eq({id: 123})
+        expect(result.annotations).to eq({
+          audience: ["user", "assistant"],
+          lastModified: "2025-01-12T15:00:58Z",
+          priority: 1.0
+        })
+      end
+    end
+  end
+
+  describe "#image_content" do
+    context "with valid data" do
+      it "returns an Image content object with required parameters" do
+        result = helper.image_content(data: "base64data", mime_type: "image/png")
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Image)
+        expect(result.data).to eq("base64data")
+        expect(result.mime_type).to eq("image/png")
+        expect(result.meta).to be_nil
+        expect(result.annotations).to be_nil
+      end
+
+      it "returns an Image content object with meta" do
+        result = helper.image_content(
+          data: "base64data",
+          mime_type: "image/jpeg",
+          meta: {camera: "front"}
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Image)
+        expect(result.data).to eq("base64data")
+        expect(result.mime_type).to eq("image/jpeg")
+        expect(result.meta).to eq({camera: "front"})
+        expect(result.annotations).to be_nil
+      end
+
+      it "returns an Image content object with annotations" do
+        annotations = {audience: "assistant", priority: 0.5}
+        result = helper.image_content(
+          data: "base64data",
+          mime_type: "image/gif",
+          annotations: annotations
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Image)
+        expect(result.data).to eq("base64data")
+        expect(result.mime_type).to eq("image/gif")
+        expect(result.meta).to be_nil
+        expect(result.annotations).to eq({audience: "assistant", priority: 0.5})
+      end
+
+      it "returns an Image content object with all parameters" do
+        annotations = {audience: "user", last_modified: "2025-01-12T15:00:58.123Z"}
+        result = helper.image_content(
+          data: "base64data",
+          mime_type: "image/webp",
+          meta: {width: 800, height: 600},
+          annotations: annotations
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Image)
+        expect(result.data).to eq("base64data")
+        expect(result.mime_type).to eq("image/webp")
+        expect(result.meta).to eq({width: 800, height: 600})
+        expect(result.annotations).to eq({
+          audience: "user",
+          lastModified: "2025-01-12T15:00:58.123Z"
+        })
+      end
+    end
+  end
+
+  describe "#audio_content" do
+    context "with valid data" do
+      it "returns an Audio content object with required parameters" do
+        result = helper.audio_content(data: "base64audio", mime_type: "audio/mp3")
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Audio)
+        expect(result.data).to eq("base64audio")
+        expect(result.mime_type).to eq("audio/mp3")
+        expect(result.meta).to be_nil
+        expect(result.annotations).to be_nil
+      end
+
+      it "returns an Audio content object with meta" do
+        result = helper.audio_content(
+          data: "base64audio",
+          mime_type: "audio/wav",
+          meta: {duration: 120}
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Audio)
+        expect(result.data).to eq("base64audio")
+        expect(result.mime_type).to eq("audio/wav")
+        expect(result.meta).to eq({duration: 120})
+        expect(result.annotations).to be_nil
+      end
+
+      it "returns an Audio content object with annotations" do
+        annotations = {audience: ["user"], priority: 0.9}
+        result = helper.audio_content(
+          data: "base64audio",
+          mime_type: "audio/ogg",
+          annotations: annotations
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Audio)
+        expect(result.data).to eq("base64audio")
+        expect(result.mime_type).to eq("audio/ogg")
+        expect(result.meta).to be_nil
+        expect(result.annotations).to eq({audience: ["user"], priority: 0.9})
+      end
+
+      it "returns an Audio content object with all parameters" do
+        annotations = {audience: "assistant", last_modified: "2025-01-12T15:00:58Z", priority: 0.7}
+        result = helper.audio_content(
+          data: "base64audio",
+          mime_type: "audio/flac",
+          meta: {bitrate: 320, duration: 240},
+          annotations: annotations
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::Audio)
+        expect(result.data).to eq("base64audio")
+        expect(result.mime_type).to eq("audio/flac")
+        expect(result.meta).to eq({bitrate: 320, duration: 240})
+        expect(result.annotations).to eq({
+          audience: "assistant",
+          lastModified: "2025-01-12T15:00:58Z",
+          priority: 0.7
+        })
+      end
+    end
+  end
+
+  describe "#embedded_resource_content" do
+    context "with valid data" do
+      let(:resource) { double("resource", serialized: {uri: "file://test.txt", name: "test.txt"}) }
+
+      it "returns an EmbeddedResource content object with required parameters" do
+        result = helper.embedded_resource_content(resource: resource)
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::EmbeddedResource)
+        expect(result.resource).to eq(resource)
+        expect(result.meta).to be_nil
+        expect(result.annotations).to be_nil
+      end
+
+      it "returns an EmbeddedResource content object with meta" do
+        result = helper.embedded_resource_content(
+          resource: resource,
+          meta: {source: "filesystem"}
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::EmbeddedResource)
+        expect(result.resource).to eq(resource)
+        expect(result.meta).to eq({source: "filesystem"})
+        expect(result.annotations).to be_nil
+      end
+
+      it "returns an EmbeddedResource content object with annotations" do
+        annotations = {audience: "user", priority: 0.6}
+        result = helper.embedded_resource_content(
+          resource: resource,
+          annotations: annotations
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::EmbeddedResource)
+        expect(result.resource).to eq(resource)
+        expect(result.meta).to be_nil
+        expect(result.annotations).to eq({audience: "user", priority: 0.6})
+      end
+
+      it "returns an EmbeddedResource content object with all parameters" do
+        annotations = {audience: ["assistant", "user"], last_modified: "2025-01-12T15:00:58.999Z"}
+        result = helper.embedded_resource_content(
+          resource: resource,
+          meta: {cached: true},
+          annotations: annotations
+        )
+
+        expect(result).to be_a(ModelContextProtocol::Server::Content::EmbeddedResource)
+        expect(result.resource).to eq(resource)
+        expect(result.meta).to eq({cached: true})
+        expect(result.annotations).to eq({
+          audience: ["assistant", "user"],
+          lastModified: "2025-01-12T15:00:58.999Z"
+        })
+      end
+    end
+  end
+
+  describe "#resource_link" do
+    context "with valid data" do
+      it "returns a serialized ResourceLink hash with required parameters" do
+        result = helper.resource_link(name: "test-file", uri: "https://example.com/test.txt")
+
+        expect(result).to be_a(Hash)
+        expect(result[:name]).to eq("test-file")
+        expect(result[:uri]).to eq("https://example.com/test.txt")
+        expect(result[:type]).to eq("resource_link")
+      end
+
+      it "returns a serialized ResourceLink hash with meta" do
+        result = helper.resource_link(
+          name: "test-file",
+          uri: "https://example.com/test.txt",
+          meta: {api_version: "v1"}
+        )
+
+        expect(result).to be_a(Hash)
+        expect(result[:name]).to eq("test-file")
+        expect(result[:uri]).to eq("https://example.com/test.txt")
+        expect(result[:type]).to eq("resource_link")
+        expect(result[:_meta]).to eq({api_version: "v1"})
+      end
+
+      it "returns a serialized ResourceLink hash with annotations" do
+        annotations = {audience: "user", priority: 0.8}
+        result = helper.resource_link(
+          name: "test-file",
+          uri: "https://example.com/test.txt",
+          annotations: annotations
+        )
+
+        expect(result).to be_a(Hash)
+        expect(result[:name]).to eq("test-file")
+        expect(result[:uri]).to eq("https://example.com/test.txt")
+        expect(result[:type]).to eq("resource_link")
+        expect(result[:annotations]).to eq({audience: "user", priority: 0.8})
+      end
+
+      it "returns a serialized ResourceLink hash with all optional parameters" do
+        annotations = {audience: ["user", "assistant"], last_modified: "2025-01-12T15:00:58Z", priority: 1.0}
+        result = helper.resource_link(
+          name: "test-file",
+          uri: "https://example.com/test.txt",
+          meta: {external: true},
+          annotations: annotations,
+          description: "A test file",
+          mime_type: "text/plain",
+          size: 1024,
+          title: "Test File"
+        )
+
+        expect(result).to be_a(Hash)
+        expect(result[:name]).to eq("test-file")
+        expect(result[:uri]).to eq("https://example.com/test.txt")
+        expect(result[:type]).to eq("resource_link")
+        expect(result[:_meta]).to eq({external: true})
+        expect(result[:annotations]).to eq({
+          audience: ["user", "assistant"],
+          lastModified: "2025-01-12T15:00:58Z",
+          priority: 1.0
+        })
+        expect(result[:description]).to eq("A test file")
+        expect(result[:mimeType]).to eq("text/plain")
+        expect(result[:size]).to eq(1024)
+        expect(result[:title]).to eq("Test File")
+      end
+
+      it "returns a serialized ResourceLink hash with only some optional parameters" do
+        result = helper.resource_link(
+          name: "test-file",
+          uri: "https://example.com/test.txt",
+          description: "A test file",
+          size: 2048
+        )
+
+        expect(result).to be_a(Hash)
+        expect(result[:name]).to eq("test-file")
+        expect(result[:uri]).to eq("https://example.com/test.txt")
+        expect(result[:type]).to eq("resource_link")
+        expect(result[:description]).to eq("A test file")
+        expect(result[:size]).to eq(2048)
+        expect(result).not_to have_key(:_meta)
+        expect(result).not_to have_key(:annotations)
+        expect(result).not_to have_key(:mimeType)
+        expect(result).not_to have_key(:title)
+      end
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/content_spec.rb
+++ b/spec/lib/model_context_protocol/server/content_spec.rb
@@ -1,0 +1,521 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::Content do
+  describe ModelContextProtocol::Server::Content::Text do
+    describe "#serialized" do
+      context "with valid data" do
+        it "returns a valid hash with required fields" do
+          text = described_class.new(meta: nil, annotations: nil, text: "Hello world")
+          result = text.serialized
+
+          expect(result).to eq({
+            text: "Hello world",
+            type: "text"
+          })
+        end
+
+        it "returns a valid hash with meta and annotations" do
+          annotations = ModelContextProtocol::Server::Content::Annotations.new(
+            audience: "user",
+            last_modified: nil,
+            priority: nil
+          ).serialized
+
+          text = described_class.new(
+            meta: {custom: "data"},
+            annotations: annotations,
+            text: "Hello world"
+          )
+          result = text.serialized
+
+          expect(result).to eq({
+            _meta: {custom: "data"},
+            annotations: {audience: "user"},
+            text: "Hello world",
+            type: "text"
+          })
+        end
+      end
+
+      context "with invalid data" do
+        it "raises ContentValidationError when text is missing" do
+          text = described_class.new(meta: nil, annotations: nil, text: nil)
+
+          expect { text.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError when text is not a string" do
+          text = described_class.new(meta: nil, annotations: nil, text: 123)
+
+          expect { text.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+      end
+    end
+  end
+
+  describe ModelContextProtocol::Server::Content::Image do
+    describe "#serialized" do
+      context "with valid data" do
+        it "returns a valid hash with required fields" do
+          image = described_class.new(
+            meta: nil,
+            annotations: nil,
+            data: "base64encodeddata",
+            mime_type: "image/png"
+          )
+          result = image.serialized
+
+          expect(result).to eq({
+            data: "base64encodeddata",
+            mimeType: "image/png",
+            type: "image"
+          })
+        end
+
+        it "returns a valid hash with meta and annotations" do
+          annotations = ModelContextProtocol::Server::Content::Annotations.new(
+            audience: ["user", "assistant"],
+            last_modified: nil,
+            priority: 0.8
+          ).serialized
+          image = described_class.new(
+            meta: {source: "camera"},
+            annotations: annotations,
+            data: "base64encodeddata",
+            mime_type: "image/jpeg"
+          )
+          result = image.serialized
+
+          expect(result).to eq({
+            _meta: {source: "camera"},
+            annotations: {audience: ["user", "assistant"], priority: 0.8},
+            data: "base64encodeddata",
+            mimeType: "image/jpeg",
+            type: "image"
+          })
+        end
+      end
+
+      context "with invalid data" do
+        it "raises ContentValidationError when data is missing" do
+          image = described_class.new(
+            meta: nil,
+            annotations: nil,
+            data: nil,
+            mime_type: "image/png"
+          )
+
+          expect { image.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError when mime_type is missing" do
+          image = described_class.new(
+            meta: nil,
+            annotations: nil,
+            data: "base64encodeddata",
+            mime_type: nil
+          )
+
+          expect { image.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError when data is not a string" do
+          image = described_class.new(
+            meta: nil,
+            annotations: nil,
+            data: 123,
+            mime_type: "image/png"
+          )
+
+          expect { image.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+      end
+    end
+  end
+
+  describe ModelContextProtocol::Server::Content::Audio do
+    describe "#serialized" do
+      context "with valid data" do
+        it "returns a valid hash with required fields" do
+          audio = described_class.new(
+            meta: nil,
+            annotations: nil,
+            data: "base64encodedaudiodata",
+            mime_type: "audio/mp3"
+          )
+          result = audio.serialized
+
+          expect(result).to eq({
+            data: "base64encodedaudiodata",
+            mimeType: "audio/mp3",
+            type: "audio"
+          })
+        end
+
+        it "returns a valid hash with meta and annotations" do
+          annotations = ModelContextProtocol::Server::Content::Annotations.new(
+            audience: "assistant",
+            last_modified: "2025-01-12T15:00:58Z",
+            priority: nil
+          ).serialized
+          audio = described_class.new(
+            meta: {duration: 120},
+            annotations: annotations,
+            data: "base64encodedaudiodata",
+            mime_type: "audio/wav"
+          )
+          result = audio.serialized
+
+          expect(result).to eq({
+            _meta: {duration: 120},
+            annotations: {audience: "assistant", lastModified: "2025-01-12T15:00:58Z"},
+            data: "base64encodedaudiodata",
+            mimeType: "audio/wav",
+            type: "audio"
+          })
+        end
+      end
+
+      context "with invalid data" do
+        it "raises ContentValidationError when data is missing" do
+          audio = described_class.new(
+            meta: nil,
+            annotations: nil,
+            data: nil,
+            mime_type: "audio/mp3"
+          )
+
+          expect { audio.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError when mime_type is missing" do
+          audio = described_class.new(
+            meta: nil,
+            annotations: nil,
+            data: "base64encodedaudiodata",
+            mime_type: nil
+          )
+
+          expect { audio.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+      end
+    end
+  end
+
+  describe ModelContextProtocol::Server::Content::EmbeddedResource do
+    describe "#serialized" do
+      context "with valid data" do
+        it "returns a valid hash with required fields" do
+          resource = double("resource", serialized: {uri: "file://test.txt", name: "test.txt"})
+          embedded = described_class.new(meta: nil, annotations: nil, resource: resource)
+          result = embedded.serialized
+
+          expect(result).to eq({
+            resource: {uri: "file://test.txt", name: "test.txt"},
+            type: "resource"
+          })
+        end
+
+        it "returns a valid hash with annotations" do
+          annotations = ModelContextProtocol::Server::Content::Annotations.new(
+            audience: ["user"],
+            last_modified: nil,
+            priority: 0.5
+          ).serialized
+          resource = double("resource", serialized: {uri: "file://test.txt", name: "test.txt"})
+          embedded = described_class.new(meta: nil, annotations: annotations, resource: resource)
+          result = embedded.serialized
+
+          expect(result).to eq({
+            annotations: {audience: ["user"], priority: 0.5},
+            resource: {uri: "file://test.txt", name: "test.txt"},
+            type: "resource"
+          })
+        end
+
+        it "returns a valid hash with meta" do
+          meta = {foo: "bar"}
+          resource = double("resource", serialized: {uri: "file://test.txt", name: "test.txt"})
+          embedded = described_class.new(meta:, annotations: nil, resource:)
+          result = embedded.serialized
+
+          expect(result).to eq({
+            _meta: {foo: "bar"},
+            resource: {uri: "file://test.txt", name: "test.txt"},
+            type: "resource"
+          })
+        end
+      end
+
+      context "with invalid data" do
+        it "raises NoMethodError when resource is missing" do
+          embedded = described_class.new(meta: nil, annotations: nil, resource: nil)
+
+          expect { embedded.serialized }
+            .to raise_error(ModelContextProtocol::Server::Content::ContentValidationError)
+        end
+      end
+    end
+  end
+
+  describe ModelContextProtocol::Server::Content::ResourceLink do
+    describe "#serialized" do
+      context "with valid data" do
+        it "returns a valid hash with required fields" do
+          link = described_class.new(
+            meta: nil,
+            annotations: nil,
+            description: nil,
+            mime_type: nil,
+            name: "test-file",
+            size: nil,
+            title: nil,
+            uri: "https://example.com/test.txt"
+          )
+          result = link.serialized
+
+          expect(result).to eq({
+            name: "test-file",
+            type: "resource_link",
+            uri: "https://example.com/test.txt"
+          })
+        end
+
+        it "returns a valid hash with all optional fields" do
+          annotations = ModelContextProtocol::Server::Content::Annotations.new(
+            audience: "user",
+            last_modified: "2025-01-12T15:00:58.123Z",
+            priority: 1.0
+          ).serialized
+          link = described_class.new(
+            meta: {source: "api"},
+            annotations: annotations,
+            description: "A test file",
+            mime_type: "text/plain",
+            name: "test-file",
+            size: 1024,
+            title: "Test File",
+            uri: "https://example.com/test.txt"
+          )
+          result = link.serialized
+
+          expect(result).to eq({
+            _meta: {source: "api"},
+            annotations: {audience: "user", lastModified: "2025-01-12T15:00:58.123Z", priority: 1.0},
+            description: "A test file",
+            mimeType: "text/plain",
+            name: "test-file",
+            size: 1024,
+            title: "Test File",
+            type: "resource_link",
+            uri: "https://example.com/test.txt"
+          })
+        end
+      end
+
+      context "with invalid data" do
+        it "raises ContentValidationError when name is missing" do
+          link = described_class.new(
+            meta: nil,
+            annotations: nil,
+            description: nil,
+            mime_type: nil,
+            name: nil,
+            size: nil,
+            title: nil,
+            uri: "https://example.com/test.txt"
+          )
+
+          expect { link.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError when uri is missing" do
+          link = described_class.new(
+            meta: nil,
+            annotations: nil,
+            description: nil,
+            mime_type: nil,
+            name: "test-file",
+            size: nil,
+            title: nil,
+            uri: nil
+          )
+
+          expect { link.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError when size is not a number" do
+          link = described_class.new(
+            meta: nil,
+            annotations: nil,
+            description: nil,
+            mime_type: nil,
+            name: "test-file",
+            size: "large",
+            title: nil,
+            uri: "https://example.com/test.txt"
+          )
+
+          expect { link.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+      end
+    end
+  end
+
+  describe ModelContextProtocol::Server::Content::Annotations do
+    describe "#serialized" do
+      context "with valid data" do
+        it "returns nil when all fields are nil" do
+          annotations = described_class.new(audience: nil, last_modified: nil, priority: nil)
+          result = annotations.serialized
+
+          expect(result).to eq(nil)
+        end
+
+        it "returns hash with audience as string" do
+          annotations = described_class.new(audience: "user", last_modified: nil, priority: nil)
+          result = annotations.serialized
+
+          expect(result).to eq({audience: "user"})
+        end
+
+        it "returns hash with audience as array" do
+          annotations = described_class.new(audience: ["user", "assistant"], last_modified: nil, priority: nil)
+          result = annotations.serialized
+
+          expect(result).to eq({audience: ["user", "assistant"]})
+        end
+
+        it "returns hash with valid ISO 8601 date" do
+          annotations = described_class.new(audience: nil, last_modified: "2025-01-12T15:00:58Z", priority: nil)
+          result = annotations.serialized
+
+          expect(result).to eq({lastModified: "2025-01-12T15:00:58Z"})
+        end
+
+        it "returns hash with valid ISO 8601 date with milliseconds" do
+          annotations = described_class.new(audience: nil, last_modified: "2025-01-12T15:00:58.123Z", priority: nil)
+          result = annotations.serialized
+
+          expect(result).to eq({lastModified: "2025-01-12T15:00:58.123Z"})
+        end
+
+        it "returns hash with priority" do
+          annotations = described_class.new(audience: nil, last_modified: nil, priority: 0.5)
+          result = annotations.serialized
+
+          expect(result).to eq({priority: 0.5})
+        end
+
+        it "returns hash with all valid fields" do
+          annotations = described_class.new(
+            audience: ["assistant", "user"],
+            last_modified: "2025-01-12T15:00:58.999Z",
+            priority: 0.9
+          )
+          result = annotations.serialized
+
+          expect(result).to eq({
+            audience: ["assistant", "user"],
+            lastModified: "2025-01-12T15:00:58.999Z",
+            priority: 0.9
+          })
+        end
+      end
+
+      context "with invalid data" do
+        it "raises ContentValidationError with invalid audience string" do
+          annotations = described_class.new(audience: "invalid", last_modified: nil, priority: nil)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError with invalid audience array value" do
+          annotations = described_class.new(audience: ["user", "invalid"], last_modified: nil, priority: nil)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError with empty audience array" do
+          annotations = described_class.new(audience: [], last_modified: nil, priority: nil)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError with too many audience values" do
+          annotations = described_class.new(audience: ["user", "assistant", "system"], last_modified: nil, priority: nil)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError with duplicate audience values" do
+          annotations = described_class.new(audience: ["user", "user"], last_modified: nil, priority: nil)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError with invalid date format" do
+          annotations = described_class.new(audience: nil, last_modified: "2025-01-12", priority: nil)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError with invalid date format (no Z)" do
+          annotations = described_class.new(audience: nil, last_modified: "2025-01-12T15:00:58", priority: nil)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError with priority below minimum" do
+          annotations = described_class.new(audience: nil, last_modified: nil, priority: -0.1)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+
+        it "raises ContentValidationError with priority above maximum" do
+          annotations = described_class.new(audience: nil, last_modified: nil, priority: 1.1)
+
+          expect { annotations.serialized }.to raise_error(
+            ModelContextProtocol::Server::Content::ContentValidationError
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds content data objects and helpers for use in prompts, resources, and tools.

- **Add content data objects**
- **Implement content block helpers**
