### PR TITLE
Remove context and logging from resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,9 +277,7 @@ end
 
 The `ModelContextProtocol::Server::Resource` base class allows subclasses to define a resource that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/resources/) in the `with_metadata` block. You can also define any [resource annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#annotations) in the nested `with_annotations` block.
 
-Then, implement the `call` method to build your resource. Any context values provided in the server configuration will be available in the `context` hash. Use the `respond_with` instance method to ensure your resource responds with appropriately formatted response data.
-
-You can also log from within your resource by calling a valid logger level method on the `logger` and passing a string message.
+Then, implement the `call` method to build your resource. Use the `respond_with` instance method to ensure your resource responds with appropriately formatted response data.
 
 This is an example resource that returns a text response:
 
@@ -293,19 +291,7 @@ class TestResource < ModelContextProtocol::Server::Resource
   end
 
   def call
-    unless authorized?(context[:user_id])
-      logger.info("This fool thinks he can get my top secret plans...")
-      return respond_with :text, text: "Nothing to see here, move along."
-    end
-
     respond_with :text, text: "I'm finna eat all my wife's leftovers."
-  end
-
-  private
-
-  def authorized?(user_id)
-    authorized_users = ["42", "123456"]
-    authorized_users.any?(user_id)
   end
 end
 ```

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -149,7 +149,7 @@ module ModelContextProtocol
           raise ModelContextProtocol::Server::ParameterValidationError, "resource not found for #{uri}"
         end
 
-        resource.call(configuration.logger, configuration.context)
+        resource.call
       end
 
       router.map("resources/templates/list") do |message|

--- a/lib/model_context_protocol/server/resource.rb
+++ b/lib/model_context_protocol/server/resource.rb
@@ -1,12 +1,10 @@
 module ModelContextProtocol
   class Server::Resource
-    attr_reader :mime_type, :uri, :context, :logger
+    attr_reader :mime_type, :uri
 
-    def initialize(logger, context = {})
+    def initialize
       @mime_type = self.class.mime_type
       @uri = self.class.uri
-      @context = context
-      @logger = logger
     end
 
     def call
@@ -66,8 +64,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@annotations, @annotations&.dup)
       end
 
-      def call(logger, context = {})
-        new(logger, context).call
+      def call
+        new.call
       end
 
       def metadata

--- a/lib/model_context_protocol/server/tool.rb
+++ b/lib/model_context_protocol/server/tool.rb
@@ -33,9 +33,9 @@ module ModelContextProtocol
     end
     private_constant :ImageResponse
 
-    ResourceResponse = Data.define(:resource_klass, :logger, :context) do
+    ResourceResponse = Data.define(:resource_klass) do
       def serialized
-        resource_data = resource_klass.new(logger, context).call
+        resource_data = resource_klass.call
         {content: [{type: "resource", resource: resource_data.serialized[:contents].first}], isError: false}
       end
     end
@@ -57,7 +57,7 @@ module ModelContextProtocol
       in [:image, {data:}]
         ImageResponse[data:]
       in [:resource, {resource:}]
-        ResourceResponse[resource_klass: resource, logger:, context:]
+        ResourceResponse[resource_klass: resource]
       in [:error, {text:}]
         ToolErrorResponse[text:]
       else

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -3,16 +3,14 @@ require "spec_helper"
 RSpec.describe ModelContextProtocol::Server::Resource do
   describe ".call" do
     it "returns the response from the instance's call method" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      response = TestResource.call(logger)
+      response = TestResource.call
       aggregate_failures do
-        expect(response.text).to eq("Nothing to see here, move along.")
+        expect(response.text).to eq("I'm finna eat all my wife's leftovers.")
         expect(response.serialized).to eq(
           contents: [
             {
               mimeType: "text/plain",
-              text: "Nothing to see here, move along.",
+              text: "I'm finna eat all my wife's leftovers.",
               uri: "file:///top-secret-plans.txt"
             }
           ]
@@ -21,52 +19,9 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     end
   end
 
-  describe ".call with context" do
-    let(:context) { {user_id: "123456"} }
-
-    it "passes context to the instance" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      allow(TestResource).to receive(:new).with(logger, context).and_call_original
-      response = TestResource.call(logger, context)
-      expect(response.text).to eq("I'm finna eat all my wife's leftovers.")
-    end
-
-    it "works with empty context" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      response = TestResource.call(logger, {})
-      expect(response.text).to eq("Nothing to see here, move along.")
-    end
-
-    it "works when context is not provided" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      response = TestResource.call(logger)
-      expect(response.text).to eq("Nothing to see here, move along.")
-    end
-  end
-
   describe "#initialize" do
-    it "stores context when provided" do
-      context = {user_id: "123"}
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      resource = TestResource.new(logger, context)
-      expect(resource.context).to eq(context)
-    end
-
-    it "defaults to empty hash when no context provided" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      resource = TestResource.new(logger)
-      expect(resource.context).to eq({})
-    end
-
     it "sets mime_type and uri from class metadata" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      resource = TestResource.new(logger)
+      resource = TestResource.new
       expect(resource.mime_type).to eq("text/plain")
       expect(resource.uri).to eq("file:///top-secret-plans.txt")
     end
@@ -75,14 +30,12 @@ RSpec.describe ModelContextProtocol::Server::Resource do
   describe "responses" do
     describe "text response" do
       it "formats text responses correctly" do
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        response = TestResource.call(logger)
+        response = TestResource.call
         expect(response.serialized).to eq(
           contents: [
             {
               mimeType: "text/plain",
-              text: "Nothing to see here, move along.",
+              text: "I'm finna eat all my wife's leftovers.",
               uri: "file:///top-secret-plans.txt"
             }
           ]
@@ -92,9 +45,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
     describe "binary response" do
       it "formats binary responses correctly" do
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        response = TestBinaryResource.call(logger)
+        response = TestBinaryResource.call
 
         expect(response.serialized).to eq(
           contents: [
@@ -144,8 +95,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
       end
 
       it "includes annotations in serialized response" do
-        logger = double("logger")
-        response = TestAnnotatedResource.call(logger)
+        response = TestAnnotatedResource.call
 
         expect(response.serialized).to eq(
           contents: [
@@ -170,9 +120,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
       end
 
       it "does not include annotations in serialized response" do
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        response = TestResource.call(logger)
+        response = TestResource.call
 
         content = response.serialized[:contents].first
         expect(content).not_to have_key(:annotations)

--- a/spec/lib/model_context_protocol/server/tool_spec.rb
+++ b/spec/lib/model_context_protocol/server/tool_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
               type: "resource",
               resource: {
                 mimeType: "text/plain",
-                text: "Nothing to see here, move along.",
+                text: "I'm finna eat all my wife's leftovers.",
                 uri: "file:///top-secret-plans.txt"
               }
             ],

--- a/spec/lib/model_context_protocol/server_spec.rb
+++ b/spec/lib/model_context_protocol/server_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe ModelContextProtocol::Server do
           contents: [
             {
               mimeType: "text/plain",
-              text: "Nothing to see here, move along.",
+              text: "I'm finna eat all my wife's leftovers.",
               uri: "file:///top-secret-plans.txt"
             }
           ]

--- a/spec/support/resources/test_resource.rb
+++ b/spec/support/resources/test_resource.rb
@@ -7,18 +7,6 @@ class TestResource < ModelContextProtocol::Server::Resource
   end
 
   def call
-    unless authorized?(context[:user_id])
-      logger.info("This fool thinks he can get my top secret plans...")
-      return respond_with :text, text: "Nothing to see here, move along."
-    end
-
     respond_with :text, text: "I'm finna eat all my wife's leftovers."
-  end
-
-  private
-
-  def authorized?(user_id)
-    authorized_users = ["42", "123456"]
-    authorized_users.any?(user_id)
   end
 end


### PR DESCRIPTION
This PR removes context and logging from resources. Providing context and logging to resources introduces some headaches with little benefit (i.e. makes it difficult to use embedded resources in responses from tools and prompts). If a use case arises for having context and logging in resources, we can reconsider.
