### PR TITLE
Rename annotations block

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ end
 
 #### Resources
 
-The `ModelContextProtocol::Server::Resource` base class allows subclasses to define a resource that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/resources/) in the `with_metadata` block. You can also define any [resource annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#annotations) in the nested `with_annotations` block.
+The `ModelContextProtocol::Server::Resource` base class allows subclasses to define a resource that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/resources/) in the `with_metadata` block. You can also define any [resource annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#annotations) in the nested `annotations` block.
 
 Then, implement the `call` method to build your resource. Use the `respond_with` instance method to ensure your resource responds with appropriately formatted response data.
 
@@ -305,8 +305,7 @@ class TestAnnotatedResource < ModelContextProtocol::Server::Resource
     description "A document with annotations showing priority and audience"
     mime_type "text/markdown"
     uri "file:///docs/annotated-document.md"
-
-    with_annotations do
+    annotations do
       audience [:user, :assistant]
       priority 0.9
       last_modified "2025-01-12T15:00:58Z"

--- a/lib/model_context_protocol/server/resource.rb
+++ b/lib/model_context_protocol/server/resource.rb
@@ -53,7 +53,7 @@ module ModelContextProtocol
         @description = metadata_dsl.description
         @mime_type = metadata_dsl.mime_type
         @uri = metadata_dsl.uri
-        @annotations = metadata_dsl.annotations
+        @annotations = metadata_dsl.defined_annotations
       end
 
       def inherited(subclass)
@@ -76,7 +76,7 @@ module ModelContextProtocol
     end
 
     class MetadataDSL
-      attr_reader :annotations
+      attr_reader :defined_annotations
 
       def name(value = nil)
         @name = value if value
@@ -98,10 +98,10 @@ module ModelContextProtocol
         @uri
       end
 
-      def with_annotations(&block)
-        @annotations = AnnotationsDSL.new
-        @annotations.instance_eval(&block)
-        @annotations
+      def annotations(&block)
+        @defined_annotations = AnnotationsDSL.new
+        @defined_annotations.instance_eval(&block)
+        @defined_annotations
       end
     end
 

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
               with_metadata do
-                with_annotations do
+                annotations do
                   audience :user
                 end
               end
@@ -145,7 +145,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
               with_metadata do
-                with_annotations do
+                annotations do
                   audience [:user, :assistant]
                 end
               end
@@ -157,7 +157,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
               with_metadata do
-                with_annotations do
+                annotations do
                   audience :invalid
                 end
               end
@@ -171,7 +171,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
               with_metadata do
-                with_annotations do
+                annotations do
                   priority 0.5
                 end
               end
@@ -183,7 +183,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
               with_metadata do
-                with_annotations do
+                annotations do
                   priority(-0.1)
                 end
               end
@@ -195,7 +195,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
               with_metadata do
-                with_annotations do
+                annotations do
                   priority 1.1
                 end
               end
@@ -209,7 +209,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
               with_metadata do
-                with_annotations do
+                annotations do
                   last_modified "2025-01-12T15:00:58Z"
                 end
               end
@@ -221,7 +221,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
               with_metadata do
-                with_annotations do
+                annotations do
                   last_modified "not-a-date"
                 end
               end

--- a/spec/support/resources/test_annotated_resource.rb
+++ b/spec/support/resources/test_annotated_resource.rb
@@ -4,8 +4,7 @@ class TestAnnotatedResource < ModelContextProtocol::Server::Resource
     description "A document with annotations showing priority and audience"
     mime_type "text/markdown"
     uri "file:///docs/annotated-document.md"
-
-    with_annotations do
+    annotations do
       audience [:user, :assistant]
       priority 0.9
       last_modified "2025-01-12T15:00:58Z"


### PR DESCRIPTION
This PR renames the `with_annotations` block to simply `annotations`.
