### PR TITLE
Add title to prompts, resources, and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ This is an example resource that returns a text response:
 class TestResource < ModelContextProtocol::Server::Resource
   with_metadata do
     name "top-secret-plans.txt"
+    title "Top Secret Plans"
     description "Top secret plans to do top secret things"
     mime_type "text/plain"
     uri "file:///top-secret-plans.txt"

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ class TestPrompt < ModelContextProtocol::Server::Prompt
 
   with_metadata do
     name "brainstorm_excuses"
+    title "Brainstorm Excuses"
     description "A prompt for brainstorming excuses to get out of something"
 
     argument do

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ This is an example tool that returns a text response:
 class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
   with_metadata do
     name "double"
+    title "Number Doubler"
     description "Doubles the provided number"
     input_schema do
       {

--- a/lib/model_context_protocol/server/resource.rb
+++ b/lib/model_context_protocol/server/resource.rb
@@ -14,6 +14,7 @@ module ModelContextProtocol
     TextResponse = Data.define(:resource, :text) do
       def serialized
         content = {mimeType: resource.mime_type, text:, uri: resource.uri}
+        content[:title] = resource.class.title if resource.class.title
         annotations = resource.class.annotations&.serialized
         content[:annotations] = annotations if annotations
         {contents: [content]}
@@ -24,6 +25,7 @@ module ModelContextProtocol
     BinaryResponse = Data.define(:blob, :resource) do
       def serialized
         content = {blob:, mimeType: resource.mime_type, uri: resource.uri}
+        content[:title] = resource.class.title if resource.class.title
         annotations = resource.class.annotations&.serialized
         content[:annotations] = annotations if annotations
         {contents: [content]}
@@ -43,7 +45,7 @@ module ModelContextProtocol
     end
 
     class << self
-      attr_reader :name, :description, :mime_type, :uri, :annotations
+      attr_reader :name, :description, :title, :mime_type, :uri, :annotations
 
       def with_metadata(&block)
         metadata_dsl = MetadataDSL.new
@@ -51,6 +53,7 @@ module ModelContextProtocol
 
         @name = metadata_dsl.name
         @description = metadata_dsl.description
+        @title = metadata_dsl.title
         @mime_type = metadata_dsl.mime_type
         @uri = metadata_dsl.uri
         @annotations = metadata_dsl.defined_annotations
@@ -59,6 +62,7 @@ module ModelContextProtocol
       def inherited(subclass)
         subclass.instance_variable_set(:@name, @name)
         subclass.instance_variable_set(:@description, @description)
+        subclass.instance_variable_set(:@title, @title)
         subclass.instance_variable_set(:@mime_type, @mime_type)
         subclass.instance_variable_set(:@uri, @uri)
         subclass.instance_variable_set(:@annotations, @annotations&.dup)
@@ -70,6 +74,7 @@ module ModelContextProtocol
 
       def metadata
         result = {name: @name, description: @description, mimeType: @mime_type, uri: @uri}
+        result[:title] = @title if @title
         result[:annotations] = @annotations.serialized if @annotations
         result
       end
@@ -86,6 +91,11 @@ module ModelContextProtocol
       def description(value = nil)
         @description = value if value
         @description
+      end
+
+      def title(value = nil)
+        @title = value if value
+        @title
       end
 
       def mime_type(value = nil)

--- a/lib/model_context_protocol/server/tool.rb
+++ b/lib/model_context_protocol/server/tool.rb
@@ -49,7 +49,7 @@ module ModelContextProtocol
     end
 
     class << self
-      attr_reader :name, :description, :input_schema
+      attr_reader :name, :description, :title, :input_schema
 
       def with_metadata(&block)
         metadata_dsl = MetadataDSL.new
@@ -57,12 +57,14 @@ module ModelContextProtocol
 
         @name = metadata_dsl.name
         @description = metadata_dsl.description
+        @title = metadata_dsl.title
         @input_schema = metadata_dsl.input_schema
       end
 
       def inherited(subclass)
         subclass.instance_variable_set(:@name, @name)
         subclass.instance_variable_set(:@description, @description)
+        subclass.instance_variable_set(:@title, @title)
         subclass.instance_variable_set(:@input_schema, @input_schema)
       end
 
@@ -77,7 +79,9 @@ module ModelContextProtocol
       end
 
       def metadata
-        {name: @name, description: @description, inputSchema: @input_schema}
+        result = {name: @name, description: @description, inputSchema: @input_schema}
+        result[:title] = @title if @title
+        result
       end
     end
 
@@ -90,6 +94,11 @@ module ModelContextProtocol
       def description(value = nil)
         @description = value if value
         @description
+      end
+
+      def title(value = nil)
+        @title = value if value
+        @title
       end
 
       def input_schema(&block)

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
             {
               mimeType: "text/plain",
               text: "I'm finna eat all my wife's leftovers.",
+              title: "Top Secret Plans",
               uri: "file:///top-secret-plans.txt"
             }
           ]
@@ -36,6 +37,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
             {
               mimeType: "text/plain",
               text: "I'm finna eat all my wife's leftovers.",
+              title: "Top Secret Plans",
               uri: "file:///top-secret-plans.txt"
             }
           ]
@@ -75,6 +77,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     it "returns class metadata" do
       expect(TestResource.metadata).to eq(
         name: "top-secret-plans.txt",
+        title: "Top Secret Plans",
         description: "Top secret plans to do top secret things",
         mimeType: "text/plain",
         uri: "file:///top-secret-plans.txt"
@@ -229,6 +232,34 @@ RSpec.describe ModelContextProtocol::Server::Resource do
           }.to raise_error(ArgumentError, /lastModified must be in ISO 8601 format/)
         end
       end
+    end
+  end
+
+  describe "optional title field" do
+    let(:resource_without_title) do
+      Class.new(ModelContextProtocol::Server::Resource) do
+        with_metadata do
+          name "test-resource"
+          description "A test resource without title"
+          mime_type "text/plain"
+          uri "file:///test-resource"
+        end
+
+        def call
+          respond_with text: "test content"
+        end
+      end
+    end
+
+    it "does not include title in metadata when not provided" do
+      metadata = resource_without_title.metadata
+      expect(metadata).not_to have_key(:title)
+    end
+
+    it "does not include title in serialized response when not provided" do
+      response = resource_without_title.call
+      content = response.serialized[:contents].first
+      expect(content).not_to have_key(:title)
     end
   end
 end

--- a/spec/lib/model_context_protocol/server/tool_spec.rb
+++ b/spec/lib/model_context_protocol/server/tool_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     it "sets the class metadata" do
       aggregate_failures do
         expect(TestToolWithTextResponse.name).to eq("double")
+        expect(TestToolWithTextResponse.title).to eq("Number Doubler")
         expect(TestToolWithTextResponse.description).to eq("Doubles the provided number")
         expect(TestToolWithTextResponse.input_schema).to eq(
           type: "object",
@@ -282,6 +283,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     it "returns class metadata" do
       expect(TestToolWithTextResponse.metadata).to eq(
         name: "double",
+        title: "Number Doubler",
         description: "Doubles the provided number",
         inputSchema: {
           type: "object",
@@ -293,6 +295,29 @@ RSpec.describe ModelContextProtocol::Server::Tool do
           required: ["number"]
         }
       )
+    end
+  end
+
+  describe "optional title field" do
+    let(:tool_without_title) do
+      Class.new(ModelContextProtocol::Server::Tool) do
+        with_metadata do
+          name "test_tool"
+          description "A test tool without title"
+          input_schema do
+            {type: "object", properties: {}, required: []}
+          end
+        end
+
+        def call
+          respond_with content: text_content(text: "test response")
+        end
+      end
+    end
+
+    it "does not include title in metadata when not provided" do
+      metadata = tool_without_title.metadata
+      expect(metadata).not_to have_key(:title)
     end
   end
 end

--- a/spec/lib/model_context_protocol/server/tool_spec.rb
+++ b/spec/lib/model_context_protocol/server/tool_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
               resource: {
                 mimeType: "text/plain",
                 text: "I'm finna eat all my wife's leftovers.",
+                title: "Top Secret Plans",
                 uri: "file:///top-secret-plans.txt"
               }
             ],

--- a/spec/lib/model_context_protocol/server_spec.rb
+++ b/spec/lib/model_context_protocol/server_spec.rb
@@ -241,6 +241,7 @@ RSpec.describe ModelContextProtocol::Server do
             {
               mimeType: "text/plain",
               text: "I'm finna eat all my wife's leftovers.",
+              title: "Top Secret Plans",
               uri: "file:///top-secret-plans.txt"
             }
           ]

--- a/spec/support/prompts/test_prompt.rb
+++ b/spec/support/prompts/test_prompt.rb
@@ -8,6 +8,7 @@ class TestPrompt < ModelContextProtocol::Server::Prompt
 
   with_metadata do
     name "brainstorm_excuses"
+    title "Brainstorm Excuses"
     description "A prompt for brainstorming excuses to get out of something"
 
     argument do

--- a/spec/support/resources/test_resource.rb
+++ b/spec/support/resources/test_resource.rb
@@ -1,6 +1,7 @@
 class TestResource < ModelContextProtocol::Server::Resource
   with_metadata do
     name "top-secret-plans.txt"
+    title "Top Secret Plans"
     description "Top secret plans to do top secret things"
     mime_type "text/plain"
     uri "file:///top-secret-plans.txt"

--- a/spec/support/tools/test_tool_with_text_response.rb
+++ b/spec/support/tools/test_tool_with_text_response.rb
@@ -1,6 +1,7 @@
 class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
   with_metadata do
     name "double"
+    title "Number Doubler"
     description "Doubles the provided number"
     input_schema do
       {


### PR DESCRIPTION
This PR adds support for optional title fields for prompts, resources, and tools.

- **Add support for title to prompts**
- **Add title to resources**
- **Add title to tools**
