### PR TITLE
Change with_metadata to define to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ Messages from the MCP client will be routed to the appropriate custom handler. T
 
 #### Prompts
 
-The `ModelContextProtocol::Server::Prompt` base class allows subclasses to define a prompt that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/prompts/) in the `with_metadata` block.
+The `ModelContextProtocol::Server::Prompt` base class allows subclasses to define a prompt that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/prompts/) in the `define` block.
 
-Define any arguments using `argument` blocks nested within the `with_metadata` block. You can mark an argument as required, and you can optionally provide a completion class. See [Completions](#completions) for more information.
+Define any arguments using `argument` blocks nested within the `define` block. You can mark an argument as required, and you can optionally provide a completion class. See [Completions](#completions) for more information.
 
 Then implement the `call` method to build your prompt. Any arguments passed to the tool from the MCP client will be available in the `arguments` hash with symbol keys (e.g., `arguments[:argument_name]`), and any context values provided in the server configuration will be available in the `context` hash. Use the `respond_with` instance method to ensure your prompt responds with appropriately formatted response data.
 
@@ -203,7 +203,7 @@ This is an example prompt that returns a properly formatted response:
 
 ```ruby
 class TestPrompt < ModelContextProtocol::Server::Prompt
-  with_metadata do
+  define do
     name "brainstorm_excuses"
     title "Brainstorm Excuses"
     description "A prompt for brainstorming excuses to get out of something"
@@ -229,7 +229,7 @@ class TestPrompt < ModelContextProtocol::Server::Prompt
   #   respond_with values:
   # end
   #   ...
-  # with_metadata do
+  # define do
   #   argument do
   #     name "tone"
   #     description "The general tone to be used in the generated excuses"
@@ -285,7 +285,7 @@ end
 
 #### Resources
 
-The `ModelContextProtocol::Server::Resource` base class allows subclasses to define a resource that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/resources/) in the `with_metadata` block. You can also define any [resource annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#annotations) in the nested `annotations` block.
+The `ModelContextProtocol::Server::Resource` base class allows subclasses to define a resource that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/resources/) in the `define` block. You can also define any [resource annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#annotations) in the nested `annotations` block.
 
 Then, implement the `call` method to build your resource. Use the `respond_with` instance method to ensure your resource responds with appropriately formatted response data.
 
@@ -293,7 +293,7 @@ This is an example resource that returns a text response:
 
 ```ruby
 class TestResource < ModelContextProtocol::Server::Resource
-  with_metadata do
+  define do
     name "top-secret-plans.txt"
     title "Top Secret Plans"
     description "Top secret plans to do top secret things"
@@ -311,7 +311,7 @@ This is an example resource with annotations:
 
 ```ruby
 class TestAnnotatedResource < ModelContextProtocol::Server::Resource
-  with_metadata do
+  define do
     name "annotated-document.md"
     description "A document with annotations showing priority and audience"
     mime_type "text/markdown"
@@ -333,7 +333,7 @@ This is an example resource that returns binary data:
 
 ```ruby
 class TestBinaryResource < ModelContextProtocol::Server::Resource
-  with_metadata do
+  define do
     name "project-logo.png"
     description "The logo for the project"
     mime_type "image/png"
@@ -351,13 +351,13 @@ end
 
 #### Resource Templates
 
-The `ModelContextProtocol::Server::ResourceTemplate` base class allows subclasses to define a resource template that the MCP client can use. Define the [appropriate metadata](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#resource-templates) in the `with_metadata` block.
+The `ModelContextProtocol::Server::ResourceTemplate` base class allows subclasses to define a resource template that the MCP client can use. Define the [appropriate metadata](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#resource-templates) in the `define` block.
 
 This is an example resource template that provides a completion for a parameter of the URI template:
 
 ```ruby
 class TestResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
-  with_metadata do
+  define do
     name "project-document-resource-template"
     description "A resource template for retrieving project documents"
     mime_type "text/plain"
@@ -376,7 +376,7 @@ class TestResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
   #   respond_with values:
   # end
 
-  # with_metadata do
+  # define do
   #   name "project-document-resource-template"
   #   description "A resource template for retrieving project documents"
   #   mime_type "text/plain"
@@ -389,7 +389,7 @@ end
 
 #### Tools
 
-The `ModelContextProtocol::Server::Tool` base class allows subclasses to define a tool that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/tools/) in the `with_metadata` block.
+The `ModelContextProtocol::Server::Tool` base class allows subclasses to define a tool that the MCP client can use. Define the [appropriate metadata](https://spec.modelcontextprotocol.io/specification/2025-06-18/server/tools/) in the `define` block.
 
 Then, implement the `call` method to build your tool. Any arguments passed to the tool from the MCP client will be available in the `arguments` hash with symbol keys (e.g., `arguments[:argument_name]`), and any context values provided in the server configuration will be available in the `context` hash. Use the `respond_with` instance method to ensure your tool responds with appropriately formatted response data.
 
@@ -399,7 +399,7 @@ This is an example tool that returns a text response:
 
 ```ruby
 class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "double"
     title "Number Doubler"
     description "Doubles the provided number"
@@ -434,7 +434,7 @@ This is an example of a tool that returns an image:
 
 ```ruby
 class TestToolWithImageResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "custom-chart-generator"
     description "Generates a chart in various formats"
     input_schema do
@@ -479,7 +479,7 @@ This is an example of a tool that returns an embedded resource response:
 
 ```ruby
 class TestToolWithResourceResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "resource-finder"
     description "Finds a resource given a name"
     input_schema do
@@ -520,7 +520,7 @@ This is an example of a tool that returns mixed content:
 
 ```ruby
 class TestToolWithMixedContentResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "get_temperature_history"
     description "Gets comprehensive temperature history for a zip code"
     input_schema do
@@ -573,7 +573,7 @@ This is an example of a tool that returns a tool error response:
 
 ```ruby
 class TestToolWithToolErrorResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "api-caller"
     description "Makes calls to external APIs"
     input_schema do

--- a/lib/model_context_protocol/server/prompt.rb
+++ b/lib/model_context_protocol/server/prompt.rb
@@ -47,16 +47,16 @@ module ModelContextProtocol
     class << self
       attr_reader :name, :description, :title, :defined_arguments
 
-      def with_metadata(&block)
+      def define(&block)
         @defined_arguments ||= []
 
-        metadata_dsl = MetadataDSL.new
-        metadata_dsl.instance_eval(&block)
+        definition_dsl = DefinitionDSL.new
+        definition_dsl.instance_eval(&block)
 
-        @name = metadata_dsl.name
-        @description = metadata_dsl.description
-        @title = metadata_dsl.title
-        @defined_arguments.concat(metadata_dsl.arguments)
+        @name = definition_dsl.name
+        @description = definition_dsl.description
+        @title = definition_dsl.title
+        @defined_arguments.concat(definition_dsl.arguments)
       end
 
       def with_argument(&block)
@@ -86,7 +86,7 @@ module ModelContextProtocol
         raise ModelContextProtocol::Server::ParameterValidationError, error.message
       end
 
-      def metadata
+      def definition
         result = {name: @name, description: @description, arguments: @defined_arguments}
         result[:title] = @title if @title
         result
@@ -99,7 +99,7 @@ module ModelContextProtocol
       end
     end
 
-    class MetadataDSL
+    class DefinitionDSL
       attr_reader :arguments
 
       def initialize

--- a/lib/model_context_protocol/server/registry.rb
+++ b/lib/model_context_protocol/server/registry.rb
@@ -39,8 +39,8 @@ module ModelContextProtocol
     end
 
     def register(klass)
-      metadata = klass.metadata
-      entry = {klass: klass}.merge(metadata)
+      definition = klass.definition
+      entry = {klass: klass}.merge(definition)
 
       case klass.ancestors
       when ->(ancestors) { ancestors.include?(ModelContextProtocol::Server::Prompt) }

--- a/lib/model_context_protocol/server/resource.rb
+++ b/lib/model_context_protocol/server/resource.rb
@@ -47,16 +47,16 @@ module ModelContextProtocol
     class << self
       attr_reader :name, :description, :title, :mime_type, :uri, :annotations
 
-      def with_metadata(&block)
-        metadata_dsl = MetadataDSL.new
-        metadata_dsl.instance_eval(&block)
+      def define(&block)
+        definition_dsl = DefinitionDSL.new
+        definition_dsl.instance_eval(&block)
 
-        @name = metadata_dsl.name
-        @description = metadata_dsl.description
-        @title = metadata_dsl.title
-        @mime_type = metadata_dsl.mime_type
-        @uri = metadata_dsl.uri
-        @annotations = metadata_dsl.defined_annotations
+        @name = definition_dsl.name
+        @description = definition_dsl.description
+        @title = definition_dsl.title
+        @mime_type = definition_dsl.mime_type
+        @uri = definition_dsl.uri
+        @annotations = definition_dsl.defined_annotations
       end
 
       def inherited(subclass)
@@ -72,7 +72,7 @@ module ModelContextProtocol
         new.call
       end
 
-      def metadata
+      def definition
         result = {name: @name, description: @description, mimeType: @mime_type, uri: @uri}
         result[:title] = @title if @title
         result[:annotations] = @annotations.serialized if @annotations
@@ -80,7 +80,7 @@ module ModelContextProtocol
       end
     end
 
-    class MetadataDSL
+    class DefinitionDSL
       attr_reader :defined_annotations
 
       def name(value = nil)

--- a/lib/model_context_protocol/server/resource_template.rb
+++ b/lib/model_context_protocol/server/resource_template.rb
@@ -3,15 +3,15 @@ module ModelContextProtocol
     class << self
       attr_reader :name, :description, :mime_type, :uri_template, :completions
 
-      def with_metadata(&block)
-        metadata_dsl = MetadataDSL.new
-        metadata_dsl.instance_eval(&block)
+      def define(&block)
+        definition_dsl = DefinitionDSL.new
+        definition_dsl.instance_eval(&block)
 
-        @name = metadata_dsl.name
-        @description = metadata_dsl.description
-        @mime_type = metadata_dsl.mime_type
-        @uri_template = metadata_dsl.uri_template
-        @completions = metadata_dsl.completions
+        @name = definition_dsl.name
+        @description = definition_dsl.description
+        @mime_type = definition_dsl.mime_type
+        @uri_template = definition_dsl.uri_template
+        @completions = definition_dsl.completions
       end
 
       def inherited(subclass)
@@ -32,7 +32,7 @@ module ModelContextProtocol
         completion.call(param_name.to_s, value)
       end
 
-      def metadata
+      def definition
         {
           name: @name,
           description: @description,
@@ -43,7 +43,7 @@ module ModelContextProtocol
       end
     end
 
-    class MetadataDSL
+    class DefinitionDSL
       attr_reader :completions
 
       def initialize

--- a/lib/model_context_protocol/server/tool.rb
+++ b/lib/model_context_protocol/server/tool.rb
@@ -51,14 +51,14 @@ module ModelContextProtocol
     class << self
       attr_reader :name, :description, :title, :input_schema
 
-      def with_metadata(&block)
-        metadata_dsl = MetadataDSL.new
-        metadata_dsl.instance_eval(&block)
+      def define(&block)
+        definition_dsl = DefinitionDSL.new
+        definition_dsl.instance_eval(&block)
 
-        @name = metadata_dsl.name
-        @description = metadata_dsl.description
-        @title = metadata_dsl.title
-        @input_schema = metadata_dsl.input_schema
+        @name = definition_dsl.name
+        @description = definition_dsl.description
+        @title = definition_dsl.title
+        @input_schema = definition_dsl.input_schema
       end
 
       def inherited(subclass)
@@ -78,14 +78,14 @@ module ModelContextProtocol
         ErrorResponse[error: error.message]
       end
 
-      def metadata
+      def definition
         result = {name: @name, description: @description, inputSchema: @input_schema}
         result[:title] = @title if @title
         result
       end
     end
 
-    class MetadataDSL
+    class DefinitionDSL
       def name(value = nil)
         @name = value if value
         @name

--- a/spec/lib/model_context_protocol/server/prompt_spec.rb
+++ b/spec/lib/model_context_protocol/server/prompt_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
     end
   end
 
-  describe ".with_metadata" do
-    it "sets the class metadata" do
+  describe ".define" do
+    it "sets the class definition" do
       aggregate_failures do
         expect(TestPrompt.name).to eq("brainstorm_excuses")
         expect(TestPrompt.title).to eq("Brainstorm Excuses")
@@ -159,9 +159,9 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
     end
   end
 
-  describe ".metadata" do
-    it "returns class metadata" do
-      metadata = TestPrompt.metadata
+  describe ".definition" do
+    it "returns class definition" do
+      metadata = TestPrompt.definition
       expect(metadata[:name]).to eq("brainstorm_excuses")
       expect(metadata[:title]).to eq("Brainstorm Excuses")
       expect(metadata[:description]).to eq("A prompt for brainstorming excuses to get out of something")
@@ -222,7 +222,7 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
   describe "optional title field" do
     let(:prompt_without_title) do
       Class.new(ModelContextProtocol::Server::Prompt) do
-        with_metadata do
+        define do
           name "test_prompt"
           description "A test prompt without title"
         end
@@ -233,8 +233,8 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
       end
     end
 
-    it "does not include title in metadata when not provided" do
-      metadata = prompt_without_title.metadata
+    it "does not include title in definition when not provided" do
+      metadata = prompt_without_title.definition
       expect(metadata).not_to have_key(:title)
     end
 

--- a/spec/lib/model_context_protocol/server/registry_spec.rb
+++ b/spec/lib/model_context_protocol/server/registry_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
                 ]
               end
             end
-            prompt_class.define_singleton_method(:metadata) do
+            prompt_class.define_singleton_method(:definition) do
               {
                 name: "prompt_#{i}",
                 description: "Test prompt #{i}",
@@ -329,7 +329,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
                 ]
               end
             end
-            resource_class.define_singleton_method(:metadata) do
+            resource_class.define_singleton_method(:definition) do
               {
                 name: "resource_#{i}",
                 description: "Test resource #{i}",
@@ -344,7 +344,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
         resource_templates do
           8.times do |i|
             template_class = Class.new(ModelContextProtocol::Server::ResourceTemplate)
-            template_class.define_singleton_method(:metadata) do
+            template_class.define_singleton_method(:definition) do
               {
                 name: "template_#{i}",
                 description: "Test template #{i}",
@@ -370,7 +370,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
                 ]
               end
             end
-            tool_class.define_singleton_method(:metadata) do
+            tool_class.define_singleton_method(:definition) do
               {
                 name: "tool_#{i}",
                 description: "Test tool #{i}",

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
   end
 
   describe "#initialize" do
-    it "sets mime_type and uri from class metadata" do
+    it "sets mime_type and uri from class definition" do
       resource = TestResource.new
       expect(resource.mime_type).to eq("text/plain")
       expect(resource.uri).to eq("file:///top-secret-plans.txt")
@@ -62,8 +62,8 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     end
   end
 
-  describe "with_metadata" do
-    it "sets the class metadata" do
+  describe "define" do
+    it "sets the class definition" do
       aggregate_failures do
         expect(TestResource.name).to eq("top-secret-plans.txt")
         expect(TestResource.description).to eq("Top secret plans to do top secret things")
@@ -73,9 +73,9 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     end
   end
 
-  describe "metadata" do
-    it "returns class metadata" do
-      expect(TestResource.metadata).to eq(
+  describe "definition" do
+    it "returns class definition" do
+      expect(TestResource.definition).to eq(
         name: "top-secret-plans.txt",
         title: "Top Secret Plans",
         description: "Top secret plans to do top secret things",
@@ -87,8 +87,8 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
   describe "annotations" do
     describe "with annotations" do
-      it "includes annotations in metadata" do
-        expect(TestAnnotatedResource.metadata).to include(
+      it "includes annotations in definition" do
+        expect(TestAnnotatedResource.definition).to include(
           annotations: {
             audience: ["user", "assistant"],
             priority: 0.9,
@@ -118,8 +118,8 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     end
 
     describe "without annotations" do
-      it "does not include annotations in metadata" do
-        expect(TestResource.metadata).not_to have_key(:annotations)
+      it "does not include annotations in definition" do
+        expect(TestResource.definition).not_to have_key(:annotations)
       end
 
       it "does not include annotations in serialized response" do
@@ -135,7 +135,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         it "accepts valid audience values" do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
-              with_metadata do
+              define do
                 annotations do
                   audience :user
                 end
@@ -147,7 +147,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         it "accepts array of valid audience values" do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
-              with_metadata do
+              define do
                 annotations do
                   audience [:user, :assistant]
                 end
@@ -159,7 +159,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         it "rejects invalid audience values" do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
-              with_metadata do
+              define do
                 annotations do
                   audience :invalid
                 end
@@ -173,7 +173,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         it "accepts valid priority values" do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
-              with_metadata do
+              define do
                 annotations do
                   priority 0.5
                 end
@@ -185,7 +185,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         it "rejects priority below 0" do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
-              with_metadata do
+              define do
                 annotations do
                   priority(-0.1)
                 end
@@ -197,7 +197,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         it "rejects priority above 1" do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
-              with_metadata do
+              define do
                 annotations do
                   priority 1.1
                 end
@@ -211,7 +211,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         it "accepts valid ISO 8601 format" do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
-              with_metadata do
+              define do
                 annotations do
                   last_modified "2025-01-12T15:00:58Z"
                 end
@@ -223,7 +223,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         it "rejects invalid date format" do
           expect {
             Class.new(ModelContextProtocol::Server::Resource) do
-              with_metadata do
+              define do
                 annotations do
                   last_modified "not-a-date"
                 end
@@ -238,7 +238,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
   describe "optional title field" do
     let(:resource_without_title) do
       Class.new(ModelContextProtocol::Server::Resource) do
-        with_metadata do
+        define do
           name "test-resource"
           description "A test resource without title"
           mime_type "text/plain"
@@ -251,8 +251,8 @@ RSpec.describe ModelContextProtocol::Server::Resource do
       end
     end
 
-    it "does not include title in metadata when not provided" do
-      metadata = resource_without_title.metadata
+    it "does not include title in definition when not provided" do
+      metadata = resource_without_title.definition
       expect(metadata).not_to have_key(:title)
     end
 

--- a/spec/lib/model_context_protocol/server/resource_template_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_template_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe ModelContextProtocol::Server::ResourceTemplate do
-  describe "with_metadata" do
-    it "sets the class metadata" do
+  describe "define" do
+    it "sets the class definition" do
       aggregate_failures do
         expect(TestResourceTemplate.name).to eq("project-document-resource-template")
         expect(TestResourceTemplate.description).to eq("A resource template for retrieving project documents")
@@ -13,9 +13,9 @@ RSpec.describe ModelContextProtocol::Server::ResourceTemplate do
     end
   end
 
-  describe "metadata" do
-    it "returns class metadata" do
-      metadata = TestResourceTemplate.metadata
+  describe "definition" do
+    it "returns class definition" do
+      metadata = TestResourceTemplate.definition
       expect(metadata[:name]).to eq("project-document-resource-template")
       expect(metadata[:description]).to eq("A resource template for retrieving project documents")
       expect(metadata[:mimeType]).to eq("text/plain")

--- a/spec/lib/model_context_protocol/server/tool_spec.rb
+++ b/spec/lib/model_context_protocol/server/tool_spec.rb
@@ -260,8 +260,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     end
   end
 
-  describe "with_metadata" do
-    it "sets the class metadata" do
+  describe "define" do
+    it "sets the class definition" do
       aggregate_failures do
         expect(TestToolWithTextResponse.name).to eq("double")
         expect(TestToolWithTextResponse.title).to eq("Number Doubler")
@@ -279,9 +279,9 @@ RSpec.describe ModelContextProtocol::Server::Tool do
     end
   end
 
-  describe "metadata" do
-    it "returns class metadata" do
-      expect(TestToolWithTextResponse.metadata).to eq(
+  describe "definition" do
+    it "returns class definition" do
+      expect(TestToolWithTextResponse.definition).to eq(
         name: "double",
         title: "Number Doubler",
         description: "Doubles the provided number",
@@ -301,7 +301,7 @@ RSpec.describe ModelContextProtocol::Server::Tool do
   describe "optional title field" do
     let(:tool_without_title) do
       Class.new(ModelContextProtocol::Server::Tool) do
-        with_metadata do
+        define do
           name "test_tool"
           description "A test tool without title"
           input_schema do
@@ -315,8 +315,8 @@ RSpec.describe ModelContextProtocol::Server::Tool do
       end
     end
 
-    it "does not include title in metadata when not provided" do
-      metadata = tool_without_title.metadata
+    it "does not include title in definition when not provided" do
+      metadata = tool_without_title.definition
       expect(metadata).not_to have_key(:title)
     end
   end

--- a/spec/lib/model_context_protocol/server_spec.rb
+++ b/spec/lib/model_context_protocol/server_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe ModelContextProtocol::Server do
                 ]
               end
             end
-            resource_class.define_singleton_method(:metadata) do
+            resource_class.define_singleton_method(:definition) do
               {
                 name: "resource_#{i}",
                 description: "Test resource #{i}",
@@ -428,7 +428,7 @@ RSpec.describe ModelContextProtocol::Server do
                 ]
               end
             end
-            tool_class.define_singleton_method(:metadata) do
+            tool_class.define_singleton_method(:definition) do
               {
                 name: "tool_#{i}",
                 description: "Test tool #{i}",
@@ -462,7 +462,7 @@ RSpec.describe ModelContextProtocol::Server do
                 ]
               end
             end
-            prompt_class.define_singleton_method(:metadata) do
+            prompt_class.define_singleton_method(:definition) do
               {
                 name: "prompt_#{i}",
                 description: "Test prompt #{i}",

--- a/spec/support/prompts/test_array_completion_prompt.rb
+++ b/spec/support/prompts/test_array_completion_prompt.rb
@@ -1,5 +1,5 @@
 class TestArrayCompletionPrompt < ModelContextProtocol::Server::Prompt
-  with_metadata do
+  define do
     name "test_array_completion"
     description "A prompt to test array-based completions"
 

--- a/spec/support/prompts/test_prompt.rb
+++ b/spec/support/prompts/test_prompt.rb
@@ -6,7 +6,7 @@ class TestPrompt < ModelContextProtocol::Server::Prompt
     respond_with values:
   end
 
-  with_metadata do
+  define do
     name "brainstorm_excuses"
     title "Brainstorm Excuses"
     description "A prompt for brainstorming excuses to get out of something"

--- a/spec/support/resource_templates/test_array_completion_resource_template.rb
+++ b/spec/support/resource_templates/test_array_completion_resource_template.rb
@@ -1,5 +1,5 @@
 class TestArrayCompletionResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
-  with_metadata do
+  define do
     name "test-array-completion-resource-template"
     description "A resource template to test array-based completions"
     mime_type "text/plain"

--- a/spec/support/resource_templates/test_old_style_completion_resource_template.rb
+++ b/spec/support/resource_templates/test_old_style_completion_resource_template.rb
@@ -13,7 +13,7 @@ class TestOldStyleCompletionResourceTemplate < ModelContextProtocol::Server::Res
     respond_with values:
   end
 
-  with_metadata do
+  define do
     name "test-old-style-completion-resource-template"
     description "A resource template to test old-style completion classes"
     mime_type "application/json"

--- a/spec/support/resource_templates/test_resource_template.rb
+++ b/spec/support/resource_templates/test_resource_template.rb
@@ -1,5 +1,5 @@
 class TestResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
-  with_metadata do
+  define do
     name "project-document-resource-template"
     description "A resource template for retrieving project documents"
     mime_type "text/plain"
@@ -18,7 +18,7 @@ class TestResourceTemplate < ModelContextProtocol::Server::ResourceTemplate
   #   respond_with values:
   # end
 
-  # with_metadata do
+  # define do
   #   name "project-document-resource-template"
   #   description "A resource template for retrieving project documents"
   #   mime_type "text/plain"

--- a/spec/support/resources/test_annotated_resource.rb
+++ b/spec/support/resources/test_annotated_resource.rb
@@ -1,5 +1,5 @@
 class TestAnnotatedResource < ModelContextProtocol::Server::Resource
-  with_metadata do
+  define do
     name "annotated-document.md"
     description "A document with annotations showing priority and audience"
     mime_type "text/markdown"

--- a/spec/support/resources/test_binary_resource.rb
+++ b/spec/support/resources/test_binary_resource.rb
@@ -1,5 +1,5 @@
 class TestBinaryResource < ModelContextProtocol::Server::Resource
-  with_metadata do
+  define do
     name "project-logo.png"
     description "The logo for the project"
     mime_type "image/png"

--- a/spec/support/resources/test_resource.rb
+++ b/spec/support/resources/test_resource.rb
@@ -1,5 +1,5 @@
 class TestResource < ModelContextProtocol::Server::Resource
-  with_metadata do
+  define do
     name "top-secret-plans.txt"
     title "Top Secret Plans"
     description "Top secret plans to do top secret things"

--- a/spec/support/test_invalid_class.rb
+++ b/spec/support/test_invalid_class.rb
@@ -1,5 +1,5 @@
 class TestInvalidClass
-  def self.metadata
+  def self.definition
     {name: "invalid_class"}
   end
 end

--- a/spec/support/tools/test_tool_with_image_response.rb
+++ b/spec/support/tools/test_tool_with_image_response.rb
@@ -1,5 +1,5 @@
 class TestToolWithImageResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "custom-chart-generator"
     description "Generates a chart in various formats"
     input_schema do

--- a/spec/support/tools/test_tool_with_mixed_content_response.rb
+++ b/spec/support/tools/test_tool_with_mixed_content_response.rb
@@ -1,5 +1,5 @@
 class TestToolWithMixedContentResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "get_temperature_history"
     description "Gets comprehensive temperature history for a zip code"
     input_schema do

--- a/spec/support/tools/test_tool_with_resource_response.rb
+++ b/spec/support/tools/test_tool_with_resource_response.rb
@@ -1,5 +1,5 @@
 class TestToolWithResourceResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "resource-finder"
     description "Finds a resource given a name"
     input_schema do

--- a/spec/support/tools/test_tool_with_text_response.rb
+++ b/spec/support/tools/test_tool_with_text_response.rb
@@ -1,5 +1,5 @@
 class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "double"
     title "Number Doubler"
     description "Doubles the provided number"

--- a/spec/support/tools/test_tool_with_tool_error_response.rb
+++ b/spec/support/tools/test_tool_with_tool_error_response.rb
@@ -1,5 +1,5 @@
 class TestToolWithToolErrorResponse < ModelContextProtocol::Server::Tool
-  with_metadata do
+  define do
     name "api-caller"
     description "Makes calls to external APIs"
     input_schema do


### PR DESCRIPTION
Prompts, resources, resource_templates, and tools have a `_meta` field defined in the official MCP schema. This field is treated as a metadata field, which conflicts with how we reference metadata within the codebase.

As such, its better to rename `metadata` references to `definition`, and the `with_metadata` method should be renamed to `define` also. Doing so avoids any conceptual confusion that may arise when we implement support for `_meta`.

This PR handles that.
