### PR TITLE
Make streamable HTTP transport thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Make streamable HTTP transport thread-safe by using Redis to manage state.
+
 ## [0.4.0] - 2025-09-07
 
 - Implement pagination support.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # model-context-protocol-rb
 
-An implementation of the [Model Context Protocol (MCP)](https://spec.modelcontextprotocol.io/specification/2025-06-18/) in Ruby. You are welcome to contribute.
+An implementation of the [Model Context Protocol (MCP)](https://spec.modelcontextprotocol.io/specification/2025-06-18/) in Ruby.
+
+Provides simple abstractions that allow you to serve prompts, resources, resource templates, and tools via MCP locally (stdio) or in production (streamable HTTP backed by Redis) with minimal effort.
 
 ## Table of Contents
 

--- a/lib/model_context_protocol/server/streamable_http_transport/event_counter.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport/event_counter.rb
@@ -1,0 +1,35 @@
+module ModelContextProtocol
+  class Server::StreamableHttpTransport
+    class EventCounter
+      COUNTER_KEY_PREFIX = "event_counter:"
+
+      def initialize(redis_client, server_instance)
+        @redis = redis_client
+        @server_instance = server_instance
+        @counter_key = "#{COUNTER_KEY_PREFIX}#{server_instance}"
+
+        if @redis.exists(@counter_key) == 0
+          @redis.set(@counter_key, 0)
+        end
+      end
+
+      def next_event_id
+        count = @redis.incr(@counter_key)
+        "#{@server_instance}-#{count}"
+      end
+
+      def current_count
+        count = @redis.get(@counter_key)
+        count ? count.to_i : 0
+      end
+
+      def reset
+        @redis.set(@counter_key, 0)
+      end
+
+      def set_count(value)
+        @redis.set(@counter_key, value.to_i)
+      end
+    end
+  end
+end

--- a/lib/model_context_protocol/server/streamable_http_transport/notification_queue.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport/notification_queue.rb
@@ -1,0 +1,80 @@
+require "json"
+
+module ModelContextProtocol
+  class Server::StreamableHttpTransport
+    class NotificationQueue
+      QUEUE_KEY_PREFIX = "notifications:"
+      DEFAULT_MAX_SIZE = 1000
+
+      def initialize(redis_client, server_instance, max_size: DEFAULT_MAX_SIZE)
+        @redis = redis_client
+        @server_instance = server_instance
+        @queue_key = "#{QUEUE_KEY_PREFIX}#{server_instance}"
+        @max_size = max_size
+      end
+
+      def push(notification)
+        notification_json = notification.to_json
+
+        @redis.multi do |multi|
+          multi.lpush(@queue_key, notification_json)
+          multi.ltrim(@queue_key, 0, @max_size - 1)
+        end
+      end
+
+      def pop
+        notification_json = @redis.rpop(@queue_key)
+        return nil unless notification_json
+
+        JSON.parse(notification_json)
+      end
+
+      def pop_all
+        notification_jsons = @redis.multi do |multi|
+          multi.lrange(@queue_key, 0, -1)
+          multi.del(@queue_key)
+        end.first
+
+        return [] if notification_jsons.empty?
+
+        notification_jsons.reverse.map do |notification_json|
+          JSON.parse(notification_json)
+        end
+      end
+
+      def peek_all
+        notification_jsons = @redis.lrange(@queue_key, 0, -1)
+        return [] if notification_jsons.empty?
+
+        notification_jsons.reverse.map do |notification_json|
+          JSON.parse(notification_json)
+        end
+      end
+
+      def size
+        @redis.llen(@queue_key)
+      end
+
+      def empty?
+        size == 0
+      end
+
+      def clear
+        @redis.del(@queue_key)
+      end
+
+      def push_bulk(notifications)
+        return if notifications.empty?
+
+        notification_jsons = notifications.map(&:to_json)
+
+        @redis.multi do |multi|
+          notification_jsons.each do |json|
+            multi.lpush(@queue_key, json)
+          end
+          multi.ltrim(@queue_key, 0, @max_size - 1)
+        end
+      end
+    end
+  end
+end

--- a/lib/model_context_protocol/server/streamable_http_transport/session_store.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport/session_store.rb
@@ -1,10 +1,8 @@
-# frozen_string_literal: true
-
 require "json"
 require "securerandom"
 
 module ModelContextProtocol
-  class Server
+  class Server::StreamableHttpTransport
     class SessionStore
       def initialize(redis_client, ttl: 3600)
         @redis = redis_client
@@ -73,7 +71,6 @@ module ModelContextProtocol
         server_instance = get_session_server(session_id)
         return false unless server_instance
 
-        # Publish to server-specific channel
         @redis.publish("server:#{server_instance}:messages", {
           session_id: session_id,
           message: message

--- a/lib/model_context_protocol/server/streamable_http_transport/stream_registry.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport/stream_registry.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "json"
+
+module ModelContextProtocol
+  class Server::StreamableHttpTransport
+    class StreamRegistry
+      STREAM_KEY_PREFIX = "stream:active:"
+      HEARTBEAT_KEY_PREFIX = "stream:heartbeat:"
+      DEFAULT_TTL = 60 # 1 minute TTL for stream entries
+
+      def initialize(redis_client, server_instance, ttl: DEFAULT_TTL)
+        @redis = redis_client
+        @server_instance = server_instance
+        @ttl = ttl
+        @local_streams = {} # Keep local reference for direct stream access
+      end
+
+      def register_stream(session_id, stream)
+        @local_streams[session_id] = stream
+
+        # Store stream registration in Redis with TTL
+        @redis.multi do |multi|
+          multi.set("#{STREAM_KEY_PREFIX}#{session_id}", @server_instance, ex: @ttl)
+          multi.set("#{HEARTBEAT_KEY_PREFIX}#{session_id}", Time.now.to_f, ex: @ttl)
+        end
+      end
+
+      def unregister_stream(session_id)
+        @local_streams.delete(session_id)
+
+        @redis.multi do |multi|
+          multi.del("#{STREAM_KEY_PREFIX}#{session_id}")
+          multi.del("#{HEARTBEAT_KEY_PREFIX}#{session_id}")
+        end
+      end
+
+      def get_local_stream(session_id)
+        @local_streams[session_id]
+      end
+
+      def has_local_stream?(session_id)
+        @local_streams.key?(session_id)
+      end
+
+      def get_stream_server(session_id)
+        @redis.get("#{STREAM_KEY_PREFIX}#{session_id}")
+      end
+
+      def stream_active?(session_id)
+        @redis.exists("#{STREAM_KEY_PREFIX}#{session_id}") == 1
+      end
+
+      def refresh_heartbeat(session_id)
+        @redis.multi do |multi|
+          multi.set("#{HEARTBEAT_KEY_PREFIX}#{session_id}", Time.now.to_f, ex: @ttl)
+          multi.expire("#{STREAM_KEY_PREFIX}#{session_id}", @ttl)
+        end
+      end
+
+      def get_all_local_streams
+        @local_streams.dup
+      end
+
+      def has_any_local_streams?
+        !@local_streams.empty?
+      end
+
+      def cleanup_expired_streams
+        # Get all local stream session IDs
+        local_session_ids = @local_streams.keys
+
+        # Check which ones are still active in Redis
+        pipeline_results = @redis.pipelined do |pipeline|
+          local_session_ids.each do |session_id|
+            pipeline.exists("#{STREAM_KEY_PREFIX}#{session_id}")
+          end
+        end
+
+        # Remove expired streams from local storage
+        expired_sessions = []
+        local_session_ids.each_with_index do |session_id, index|
+          if pipeline_results[index] == 0 # Stream expired in Redis
+            @local_streams.delete(session_id)
+            expired_sessions << session_id
+          end
+        end
+
+        expired_sessions
+      end
+
+      def get_stale_streams(max_age_seconds = 90)
+        current_time = Time.now.to_f
+        stale_streams = []
+
+        # Get all heartbeat keys
+        heartbeat_keys = @redis.keys("#{HEARTBEAT_KEY_PREFIX}*")
+
+        return stale_streams if heartbeat_keys.empty?
+
+        # Get all heartbeat timestamps
+        heartbeat_values = @redis.mget(heartbeat_keys)
+
+        heartbeat_keys.each_with_index do |key, index|
+          next unless heartbeat_values[index]
+
+          session_id = key.sub(HEARTBEAT_KEY_PREFIX, "")
+          last_heartbeat = heartbeat_values[index].to_f
+
+          if current_time - last_heartbeat > max_age_seconds
+            stale_streams << session_id
+          end
+        end
+
+        stale_streams
+      end
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/streamable_http_transport/event_counter_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport/event_counter_spec.rb
@@ -1,0 +1,202 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport::EventCounter do
+  subject(:counter) { described_class.new(redis, server_instance) }
+
+  let(:redis) { MockRedis.new }
+  let(:server_instance) { "test-server-123" }
+
+  before do
+    redis.flushdb
+  end
+
+  describe "#initialize" do
+    it "creates a counter with the correct configuration" do
+      expect(counter.instance_variable_get(:@redis)).to eq(redis)
+      expect(counter.instance_variable_get(:@server_instance)).to eq(server_instance)
+      expect(counter.instance_variable_get(:@counter_key)).to eq("event_counter:#{server_instance}")
+    end
+
+    it "initializes the counter to 0 if it doesn't exist" do
+      fresh_redis = MockRedis.new
+      described_class.new(fresh_redis, server_instance)
+      expect(fresh_redis.get("event_counter:#{server_instance}")).to eq("0")
+    end
+
+    it "doesn't overwrite existing counter value" do
+      redis.set("event_counter:#{server_instance}", "42")
+
+      described_class.new(redis, server_instance)
+
+      expect(redis.get("event_counter:#{server_instance}")).to eq("42")
+    end
+  end
+
+  describe "#next_event_id" do
+    it "generates incrementing event IDs" do
+      id1 = counter.next_event_id
+      id2 = counter.next_event_id
+      id3 = counter.next_event_id
+
+      expect(id1).to eq("#{server_instance}-1")
+      expect(id2).to eq("#{server_instance}-2")
+      expect(id3).to eq("#{server_instance}-3")
+    end
+
+    it "uses atomic increments" do
+      ids = []
+      threads = 10.times.map do
+        Thread.new do
+          5.times { ids << counter.next_event_id }
+        end
+      end
+
+      threads.each(&:join)
+
+      aggregate_failures do
+        expect(ids.size).to eq(50)
+        expect(ids.uniq.size).to eq(50)
+
+        ids.each do |id|
+          expect(id).to match(/^#{Regexp.escape(server_instance)}-\d+$/)
+        end
+      end
+    end
+
+    it "continues from existing counter value" do
+      redis.set("event_counter:#{server_instance}", "100")
+
+      id = counter.next_event_id
+
+      expect(id).to eq("#{server_instance}-101")
+    end
+
+    it "handles very large numbers" do
+      redis.set("event_counter:#{server_instance}", "999999999")
+
+      id = counter.next_event_id
+
+      expect(id).to eq("#{server_instance}-1000000000")
+    end
+  end
+
+  describe "#current_count" do
+    it "returns 0 for new counter" do
+      expect(counter.current_count).to eq(0)
+    end
+
+    it "returns current count after increments" do
+      3.times { counter.next_event_id }
+
+      expect(counter.current_count).to eq(3)
+    end
+
+    it "returns correct count for existing counter" do
+      redis.set("event_counter:#{server_instance}", "42")
+
+      expect(counter.current_count).to eq(42)
+    end
+
+    it "handles non-existent counter gracefully" do
+      redis.del("event_counter:#{server_instance}")
+
+      expect(counter.current_count).to eq(0)
+    end
+  end
+
+  describe "#reset" do
+    it "resets counter to 0" do
+      5.times { counter.next_event_id }
+
+      counter.reset
+
+      aggregate_failures do
+        expect(counter.current_count).to eq(0)
+        expect(counter.next_event_id).to eq("#{server_instance}-1")
+      end
+    end
+
+    it "works on already zero counter" do
+      counter.reset
+
+      expect(counter.current_count).to eq(0)
+    end
+  end
+
+  describe "#set_count" do
+    it "sets the counter to a specific value" do
+      counter.set_count(100)
+
+      aggregate_failures do
+        expect(counter.current_count).to eq(100)
+        expect(counter.next_event_id).to eq("#{server_instance}-101")
+      end
+    end
+
+    it "handles string input" do
+      counter.set_count("50")
+
+      expect(counter.current_count).to eq(50)
+    end
+
+    it "handles zero value" do
+      5.times { counter.next_event_id }
+
+      counter.set_count(0)
+
+      expect(counter.current_count).to eq(0)
+    end
+
+    it "handles negative values by converting to positive" do
+      counter.set_count(-10)
+
+      expect(counter.current_count).to eq(-10)
+    end
+  end
+
+  describe "thread safety" do
+    it "maintains consistency under concurrent access" do
+      counters = 5.times.map { described_class.new(redis, server_instance) }
+
+      ids = []
+      mutex = Mutex.new
+
+      threads = counters.map do |c|
+        Thread.new do
+          10.times do
+            id = c.next_event_id
+            mutex.synchronize { ids << id }
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      aggregate_failures do
+        expect(ids.size).to eq(50)
+        expect(ids.uniq.size).to eq(50)
+        expect(counter.current_count).to eq(50)
+      end
+    end
+  end
+
+  describe "multiple server instances" do
+    it "maintains separate counters for different server instances" do
+      server2 = "different-server-456"
+      counter2 = described_class.new(redis, server2)
+
+      id1 = counter.next_event_id
+      id2 = counter2.next_event_id
+      id3 = counter.next_event_id
+
+      aggregate_failures do
+        expect(id1).to eq("#{server_instance}-1")
+        expect(id2).to eq("#{server2}-1")
+        expect(id3).to eq("#{server_instance}-2")
+
+        expect(counter.current_count).to eq(2)
+        expect(counter2.current_count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/streamable_http_transport/notification_queue_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport/notification_queue_spec.rb
@@ -1,0 +1,280 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport::NotificationQueue do
+  subject(:queue) { described_class.new(redis, server_instance, max_size: max_size) }
+
+  let(:redis) { MockRedis.new }
+  let(:server_instance) { "test-server-123" }
+  let(:max_size) { 5 }
+  let(:sample_notification) do
+    {
+      jsonrpc: "2.0",
+      method: "test_method",
+      params: {data: "test_data"}
+    }
+  end
+
+  def serialized(notification)
+    JSON.parse(notification.to_json)
+  end
+
+  def serialized_array(notifications)
+    notifications.map { |n| serialized(n) }
+  end
+
+  before do
+    redis.flushdb
+  end
+
+  describe "#initialize" do
+    it "creates a queue with the correct configuration" do
+      aggregate_failures do
+        expect(queue.instance_variable_get(:@redis)).to eq(redis)
+        expect(queue.instance_variable_get(:@server_instance)).to eq(server_instance)
+        expect(queue.instance_variable_get(:@queue_key)).to eq("notifications:#{server_instance}")
+        expect(queue.instance_variable_get(:@max_size)).to eq(max_size)
+      end
+    end
+  end
+
+  describe "#push" do
+    it "adds a notification to the queue" do
+      queue.push(sample_notification)
+
+      aggregate_failures do
+        expect(queue.size).to eq(1)
+        expect(queue.pop).to eq(serialized(sample_notification))
+      end
+    end
+
+    it "maintains FIFO order" do
+      notification1 = {method: "first"}
+      notification2 = {method: "second"}
+
+      queue.push(notification1)
+      queue.push(notification2)
+
+      aggregate_failures do
+        expect(queue.pop).to eq(serialized(notification1))
+        expect(queue.pop).to eq(serialized(notification2))
+      end
+    end
+
+    it "enforces max_size by removing oldest items" do
+      (max_size + 2).times do |i|
+        queue.push({method: "notification_#{i}"})
+      end
+
+      expect(queue.size).to eq(max_size)
+
+      popped = queue.pop
+      expect(popped["method"]).to eq("notification_2")
+    end
+  end
+
+  describe "#pop" do
+    it "returns nil when queue is empty" do
+      expect(queue.pop).to be_nil
+    end
+
+    it "removes and returns the oldest notification" do
+      queue.push(sample_notification)
+
+      result = queue.pop
+
+      aggregate_failures do
+        expect(result).to eq(serialized(sample_notification))
+        expect(queue.size).to eq(0)
+      end
+    end
+
+    it "maintains FIFO order across multiple operations" do
+      notifications = 3.times.map { |i| {method: "notification_#{i}"} }
+      notifications.each { |n| queue.push(n) }
+
+      results = 3.times.map { queue.pop }
+
+      expect(results).to eq(serialized_array(notifications))
+    end
+  end
+
+  describe "#pop_all" do
+    it "returns empty array when queue is empty" do
+      expect(queue.pop_all).to eq([])
+    end
+
+    it "returns all notifications in FIFO order and empties the queue" do
+      notifications = 3.times.map { |i| {method: "notification_#{i}"} }
+      notifications.each { |n| queue.push(n) }
+
+      results = queue.pop_all
+
+      aggregate_failures do
+        expect(results).to eq(serialized_array(notifications))
+        expect(queue.size).to eq(0)
+      end
+    end
+
+    it "is atomic - returns all or nothing" do
+      queue.push(sample_notification)
+
+      Thread.new { queue.push({method: "concurrent"}) }
+      sleep 0.01
+
+      results = queue.pop_all
+
+      aggregate_failures do
+        expect(results.size).to be >= 1
+        expect(queue.size).to eq(0)
+      end
+    end
+  end
+
+  describe "#peek_all" do
+    it "returns empty array when queue is empty" do
+      expect(queue.peek_all).to eq([])
+    end
+
+    it "returns all notifications without removing them" do
+      notifications = 3.times.map { |i| {method: "notification_#{i}"} }
+      notifications.each { |n| queue.push(n) }
+
+      results = queue.peek_all
+
+      aggregate_failures do
+        expect(results).to eq(serialized_array(notifications))
+        expect(queue.size).to eq(3)
+      end
+    end
+
+    it "returns notifications in FIFO order" do
+      notification1 = {method: "first"}
+      notification2 = {method: "second"}
+
+      queue.push(notification1)
+      queue.push(notification2)
+
+      expect(queue.peek_all).to eq([serialized(notification1), serialized(notification2)])
+    end
+  end
+
+  describe "#size" do
+    it "returns 0 for empty queue" do
+      expect(queue.size).to eq(0)
+    end
+
+    it "returns correct size after adding items" do
+      3.times { queue.push(sample_notification) }
+
+      expect(queue.size).to eq(3)
+    end
+
+    it "updates correctly after popping items" do
+      3.times { queue.push(sample_notification) }
+      queue.pop
+
+      expect(queue.size).to eq(2)
+    end
+  end
+
+  describe "#empty?" do
+    it "returns true for empty queue" do
+      expect(queue.empty?).to be true
+    end
+
+    it "returns false for non-empty queue" do
+      queue.push(sample_notification)
+
+      expect(queue.empty?).to be false
+    end
+  end
+
+  describe "#clear" do
+    it "removes all notifications from the queue" do
+      3.times { queue.push(sample_notification) }
+
+      queue.clear
+
+      aggregate_failures do
+        expect(queue.size).to eq(0)
+        expect(queue.empty?).to be true
+      end
+    end
+
+    it "works on empty queue without error" do
+      aggregate_failures do
+        expect { queue.clear }.not_to raise_error
+        expect(queue.size).to eq(0)
+      end
+    end
+  end
+
+  describe "#push_bulk" do
+    it "adds multiple notifications at once" do
+      notifications = 3.times.map { |i| {method: "notification_#{i}"} }
+
+      queue.push_bulk(notifications)
+
+      aggregate_failures do
+        expect(queue.size).to eq(3)
+        expect(queue.pop_all).to eq(serialized_array(notifications))
+      end
+    end
+
+    it "maintains FIFO order for bulk operations" do
+      batch1 = 2.times.map { |i| {method: "batch1_#{i}"} }
+      batch2 = 2.times.map { |i| {method: "batch2_#{i}"} }
+
+      queue.push_bulk(batch1)
+      queue.push_bulk(batch2)
+
+      results = queue.pop_all
+      expected = serialized_array(batch1 + batch2)
+
+      expect(results).to eq(expected)
+    end
+
+    it "enforces max_size for bulk operations" do
+      notifications = (max_size + 2).times.map { |i| {method: "notification_#{i}"} }
+
+      queue.push_bulk(notifications)
+
+      expect(queue.size).to eq(max_size)
+
+      results = queue.pop_all
+      expected = serialized_array(notifications.last(max_size))
+
+      expect(results).to eq(expected)
+    end
+
+    it "handles empty array gracefully" do
+      aggregate_failures do
+        expect { queue.push_bulk([]) }.not_to raise_error
+        expect(queue.size).to eq(0)
+      end
+    end
+  end
+
+  describe "JSON serialization" do
+    it "properly serializes and deserializes complex data structures" do
+      complex_notification = {
+        jsonrpc: "2.0",
+        method: "complex_method",
+        params: {
+          nested: {
+            array: [1, 2, 3],
+            string: "test",
+            boolean: true,
+            null_value: nil
+          }
+        }
+      }
+
+      queue.push(complex_notification)
+      result = queue.pop
+
+      expected = JSON.parse(complex_notification.to_json)
+      expect(result).to eq(expected)
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/streamable_http_transport/session_store_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport/session_store_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe ModelContextProtocol::Server::SessionStore do
+RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport::SessionStore do
   let(:redis) do
     mock_redis = MockRedis.new
     # Add pub/sub support since MockRedis doesn't have it

--- a/spec/lib/model_context_protocol/server/streamable_http_transport/stream_registry_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport/stream_registry_spec.rb
@@ -1,0 +1,222 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport::StreamRegistry do
+  subject(:registry) { described_class.new(redis, server_instance, ttl: ttl) }
+
+  let(:redis) { MockRedis.new }
+  let(:server_instance) { "test-server-123" }
+  let(:ttl) { 60 }
+  let(:session_id) { "test-session-456" }
+  let(:mock_stream) { double("stream") }
+
+  before do
+    redis.flushdb
+  end
+
+  describe "#initialize" do
+    it "creates a registry with the correct configuration" do
+      aggregate_failures do
+        expect(registry.instance_variable_get(:@redis)).to eq(redis)
+        expect(registry.instance_variable_get(:@server_instance)).to eq(server_instance)
+        expect(registry.instance_variable_get(:@ttl)).to eq(ttl)
+        expect(registry.instance_variable_get(:@local_streams)).to eq({})
+      end
+    end
+  end
+
+  describe "#register_stream" do
+    it "stores the stream locally and in Redis" do
+      registry.register_stream(session_id, mock_stream)
+
+      aggregate_failures do
+        expect(registry.get_local_stream(session_id)).to eq(mock_stream)
+        expect(redis.get("stream:active:#{session_id}")).to eq(server_instance)
+        expect(redis.ttl("stream:active:#{session_id}")).to be_within(5).of(ttl)
+        expect(redis.exists("stream:heartbeat:#{session_id}")).to eq(1)
+      end
+    end
+
+    it "sets TTL for both stream and heartbeat keys" do
+      registry.register_stream(session_id, mock_stream)
+
+      aggregate_failures do
+        expect(redis.ttl("stream:active:#{session_id}")).to be_within(5).of(ttl)
+        expect(redis.ttl("stream:heartbeat:#{session_id}")).to be_within(5).of(ttl)
+      end
+    end
+  end
+
+  describe "#unregister_stream" do
+    before do
+      registry.register_stream(session_id, mock_stream)
+    end
+
+    it "removes the stream from local storage and Redis" do
+      registry.unregister_stream(session_id)
+
+      aggregate_failures do
+        expect(registry.get_local_stream(session_id)).to be_nil
+        expect(redis.exists("stream:active:#{session_id}")).to eq(0)
+        expect(redis.exists("stream:heartbeat:#{session_id}")).to eq(0)
+      end
+    end
+  end
+
+  describe "#get_local_stream" do
+    it "returns nil when stream doesn't exist" do
+      expect(registry.get_local_stream(session_id)).to be_nil
+    end
+
+    it "returns the stream when it exists" do
+      registry.register_stream(session_id, mock_stream)
+      expect(registry.get_local_stream(session_id)).to eq(mock_stream)
+    end
+  end
+
+  describe "#has_local_stream?" do
+    it "returns false when stream doesn't exist" do
+      expect(registry.has_local_stream?(session_id)).to be false
+    end
+
+    it "returns true when stream exists" do
+      registry.register_stream(session_id, mock_stream)
+      expect(registry.has_local_stream?(session_id)).to be true
+    end
+  end
+
+  describe "#get_stream_server" do
+    it "returns nil when stream doesn't exist in Redis" do
+      expect(registry.get_stream_server(session_id)).to be_nil
+    end
+
+    it "returns the server instance when stream exists" do
+      registry.register_stream(session_id, mock_stream)
+      expect(registry.get_stream_server(session_id)).to eq(server_instance)
+    end
+  end
+
+  describe "#stream_active?" do
+    it "returns false when stream doesn't exist in Redis" do
+      expect(registry.stream_active?(session_id)).to be false
+    end
+
+    it "returns true when stream exists in Redis" do
+      registry.register_stream(session_id, mock_stream)
+      expect(registry.stream_active?(session_id)).to be true
+    end
+  end
+
+  describe "#refresh_heartbeat" do
+    before do
+      registry.register_stream(session_id, mock_stream)
+    end
+
+    it "updates the heartbeat timestamp and refreshes TTL" do
+      initial_heartbeat = redis.get("stream:heartbeat:#{session_id}")
+
+      sleep 0.01
+      registry.refresh_heartbeat(session_id)
+
+      new_heartbeat = redis.get("stream:heartbeat:#{session_id}")
+
+      aggregate_failures do
+        expect(new_heartbeat).not_to eq(initial_heartbeat)
+        expect(redis.ttl("stream:heartbeat:#{session_id}")).to be_within(5).of(ttl)
+        expect(redis.ttl("stream:active:#{session_id}")).to be_within(5).of(ttl)
+      end
+    end
+  end
+
+  describe "#get_all_local_streams" do
+    it "returns empty hash when no streams exist" do
+      expect(registry.get_all_local_streams).to eq({})
+    end
+
+    it "returns all local streams" do
+      stream1 = double("stream1")
+      stream2 = double("stream2")
+
+      registry.register_stream("session1", stream1)
+      registry.register_stream("session2", stream2)
+
+      streams = registry.get_all_local_streams
+      expect(streams).to eq({"session1" => stream1, "session2" => stream2})
+    end
+
+    it "returns a copy of the streams hash" do
+      registry.register_stream(session_id, mock_stream)
+      streams = registry.get_all_local_streams
+      streams.clear
+
+      expect(registry.get_all_local_streams).not_to be_empty
+    end
+  end
+
+  describe "#has_any_local_streams?" do
+    it "returns false when no streams exist" do
+      expect(registry.has_any_local_streams?).to be false
+    end
+
+    it "returns true when streams exist" do
+      registry.register_stream(session_id, mock_stream)
+      expect(registry.has_any_local_streams?).to be true
+    end
+  end
+
+  describe "#cleanup_expired_streams" do
+    it "removes locally stored streams that are expired in Redis" do
+      registry.register_stream("session1", double("stream1"))
+      registry.register_stream("session2", double("stream2"))
+
+      redis.del("stream:active:session1")
+
+      expired = registry.cleanup_expired_streams
+
+      aggregate_failures do
+        expect(expired).to contain_exactly("session1")
+        expect(registry.has_local_stream?("session1")).to be false
+        expect(registry.has_local_stream?("session2")).to be true
+      end
+    end
+
+    it "returns empty array when no streams are expired" do
+      registry.register_stream(session_id, mock_stream)
+
+      expired = registry.cleanup_expired_streams
+
+      aggregate_failures do
+        expect(expired).to be_empty
+        expect(registry.has_local_stream?(session_id)).to be true
+      end
+    end
+  end
+
+  describe "#get_stale_streams" do
+    it "returns streams with old heartbeats" do
+      registry.register_stream(session_id, mock_stream)
+
+      old_time = Time.now.to_f - 120
+      redis.set("stream:heartbeat:#{session_id}", old_time)
+
+      stale_streams = registry.get_stale_streams(90)
+
+      expect(stale_streams).to contain_exactly(session_id)
+    end
+
+    it "returns empty array when no streams are stale" do
+      registry.register_stream(session_id, mock_stream)
+
+      stale_streams = registry.get_stale_streams(90)
+
+      expect(stale_streams).to be_empty
+    end
+
+    it "handles missing heartbeat values gracefully" do
+      redis.set("stream:active:#{session_id}", server_instance)
+
+      stale_streams = registry.get_stale_streams(90)
+
+      expect(stale_streams).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This PR refactors the streamable HTTP transport to achieve thread-safety by integrating with Redis to manage state.

- **Make streamable HTTP transport thread-safe with Redis**
- **Update documentation**
