### PR TITLE
Refactor redis integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 bin/dev
 bin/dev-http
+
+plans/
+plans/*

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ group :development do
   gem "rack"
   gem "rackup"
   gem "rake"
-  gem "redis"
   gem "reek"
   gem "standard"
   gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,9 @@ PATH
   specs:
     model-context-protocol-rb (0.4.0)
       addressable (~> 2.8)
+      connection_pool (~> 2.4)
       json-schema (~> 5.1)
+      redis (~> 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -150,7 +152,6 @@ DEPENDENCIES
   rack
   rackup
   rake
-  redis
   reek
   rspec
   standard

--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,18 @@ gem install model-context-protocol-rb
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rspec` to run the tests.
 
+### SSL Certificates for HTTPS Testing
+
+If you need to test with HTTPS (e.g., for clients that require SSL), generate self-signed certificates:
+
+```bash
+# Create SSL directory and generate certificates
+mkdir -p tmp/ssl
+openssl req -x509 -newkey rsa:4096 -keyout tmp/ssl/server.key -out tmp/ssl/server.crt -days 365 -nodes -subj "/C=US/ST=Dev/L=Dev/O=Dev/CN=localhost"
+```
+
+### Generate Development Servers
+
 Generate executables that you can use for testing:
 
 ```bash
@@ -1082,6 +1094,16 @@ bundle exec rake mcp:generate_stdio_server
 
 # generates bin/dev-http for streamable HTTP transport
 bundle exec rake mcp:generate_streamable_http_server
+```
+
+The HTTP server supports both HTTP and HTTPS:
+
+```bash
+# Run HTTP server (default)
+bin/dev-http
+
+# Run HTTPS server (requires SSL certificates in tmp/ssl/)
+SSL=true bin/dev-http
 ```
 
 You can also run `bin/console` for an interactive prompt that will allow you to experiment. Execute command `rp` to reload the project.

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -281,5 +281,11 @@ module ModelContextProtocol
         end
       end
     end
+
+    class << self
+      def configure_redis(&block)
+        RedisConfig.configure(&block)
+      end
+    end
   end
 end

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -8,7 +8,7 @@ module ModelContextProtocol
     # Raised when invalid parameters are provided.
     class ParameterValidationError < StandardError; end
 
-    attr_reader :configuration, :router
+    attr_reader :configuration, :router, :transport
 
     def initialize
       @configuration = Configuration.new
@@ -20,7 +20,7 @@ module ModelContextProtocol
     def start
       configuration.validate!
 
-      transport = case configuration.transport_type
+      @transport = case configuration.transport_type
       when :stdio, nil
         StdioTransport.new(router: @router, configuration: @configuration)
       when :streamable_http
@@ -32,7 +32,7 @@ module ModelContextProtocol
         raise ArgumentError, "Unknown transport: #{configuration.transport_type}"
       end
 
-      transport.handle
+      @transport.handle
     end
 
     private

--- a/lib/model_context_protocol/server/configuration.rb
+++ b/lib/model_context_protocol/server/configuration.rb
@@ -200,15 +200,10 @@ module ModelContextProtocol
     end
 
     def validate_streamable_http_transport!
-      options = transport_options
-
-      unless options[:redis_client]
-        raise InvalidTransportError, "streamable_http transport requires redis_client option"
-      end
-
-      redis_client = options[:redis_client]
-      unless redis_client.respond_to?(:hset) && redis_client.respond_to?(:expire)
-        raise InvalidTransportError, "redis_client must be a Redis-compatible client"
+      unless ModelContextProtocol::Server::RedisConfig.configured?
+        raise InvalidTransportError,
+          "streamable_http transport requires Redis configuration. " \
+          "Call ModelContextProtocol::Server.configure_redis in an initializer."
       end
     end
 

--- a/lib/model_context_protocol/server/redis_client_proxy.rb
+++ b/lib/model_context_protocol/server/redis_client_proxy.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module ModelContextProtocol
+  class Server
+    class RedisClientProxy
+      def initialize(pool)
+        @pool = pool
+      end
+
+      def get(key)
+        with_connection { |redis| redis.get(key) }
+      end
+
+      def set(key, value, **options)
+        with_connection { |redis| redis.set(key, value, **options) }
+      end
+
+      def del(*keys)
+        with_connection { |redis| redis.del(*keys) }
+      end
+
+      def exists(*keys)
+        with_connection { |redis| redis.exists(*keys) }
+      end
+
+      def expire(key, seconds)
+        with_connection { |redis| redis.expire(key, seconds) }
+      end
+
+      def ttl(key)
+        with_connection { |redis| redis.ttl(key) }
+      end
+
+      def hget(key, field)
+        with_connection { |redis| redis.hget(key, field) }
+      end
+
+      def hset(key, *args)
+        with_connection { |redis| redis.hset(key, *args) }
+      end
+
+      def hgetall(key)
+        with_connection { |redis| redis.hgetall(key) }
+      end
+
+      def lpush(key, *values)
+        with_connection { |redis| redis.lpush(key, *values) }
+      end
+
+      def rpop(key)
+        with_connection { |redis| redis.rpop(key) }
+      end
+
+      def lrange(key, start, stop)
+        with_connection { |redis| redis.lrange(key, start, stop) }
+      end
+
+      def llen(key)
+        with_connection { |redis| redis.llen(key) }
+      end
+
+      def ltrim(key, start, stop)
+        with_connection { |redis| redis.ltrim(key, start, stop) }
+      end
+
+      def incr(key)
+        with_connection { |redis| redis.incr(key) }
+      end
+
+      def decr(key)
+        with_connection { |redis| redis.decr(key) }
+      end
+
+      def keys(pattern)
+        with_connection { |redis| redis.keys(pattern) }
+      end
+
+      def multi(&block)
+        with_connection do |redis|
+          redis.multi do |multi|
+            multi_wrapper = RedisMultiWrapper.new(multi)
+            block.call(multi_wrapper)
+          end
+        end
+      end
+
+      def pipelined(&block)
+        with_connection do |redis|
+          redis.pipelined do |pipeline|
+            pipeline_wrapper = RedisMultiWrapper.new(pipeline)
+            block.call(pipeline_wrapper)
+          end
+        end
+      end
+
+      def mget(*keys)
+        with_connection { |redis| redis.mget(*keys) }
+      end
+
+      def eval(script, keys: [], argv: [])
+        with_connection { |redis| redis.eval(script, keys: keys, argv: argv) }
+      end
+
+      def ping
+        with_connection { |redis| redis.ping }
+      end
+
+      def flushdb
+        with_connection { |redis| redis.flushdb }
+      end
+
+      private
+
+      def with_connection(&block)
+        @pool.with(&block)
+      end
+
+      # Wrapper for Redis multi/pipeline operations
+      class RedisMultiWrapper
+        def initialize(multi)
+          @multi = multi
+        end
+
+        def method_missing(method, *args, **kwargs, &block)
+          @multi.send(method, *args, **kwargs, &block)
+        end
+
+        def respond_to_missing?(method, include_private = false)
+          @multi.respond_to?(method, include_private)
+        end
+      end
+    end
+  end
+end

--- a/lib/model_context_protocol/server/redis_config.rb
+++ b/lib/model_context_protocol/server/redis_config.rb
@@ -36,6 +36,10 @@ module ModelContextProtocol
       instance.stats
     end
 
+    def self.pool_manager
+      instance.manager
+    end
+
     def initialize
       reset!
     end
@@ -80,6 +84,11 @@ module ModelContextProtocol
     def reset!
       shutdown!
       @manager = nil
+    end
+
+    def stats
+      return {} unless configured?
+      @manager.stats
     end
 
     class Configuration

--- a/lib/model_context_protocol/server/redis_config.rb
+++ b/lib/model_context_protocol/server/redis_config.rb
@@ -1,0 +1,99 @@
+require "singleton"
+
+module ModelContextProtocol
+  class Server::RedisConfig
+    include Singleton
+
+    class NotConfiguredError < StandardError
+      def initialize
+        super("Redis not configured. Call ModelContextProtocol::Server.configure_redis first")
+      end
+    end
+
+    attr_reader :manager
+
+    def self.configure(&block)
+      instance.configure(&block)
+    end
+
+    def self.configured?
+      instance.configured?
+    end
+
+    def self.pool
+      instance.pool
+    end
+
+    def self.shutdown!
+      instance.shutdown!
+    end
+
+    def self.reset!
+      instance.reset!
+    end
+
+    def self.stats
+      instance.stats
+    end
+
+    def initialize
+      reset!
+    end
+
+    def configure(&block)
+      shutdown! if configured?
+
+      config = Configuration.new
+      yield(config) if block_given?
+
+      @manager = Server::RedisPoolManager.new(
+        redis_url: config.redis_url,
+        pool_size: config.pool_size,
+        pool_timeout: config.pool_timeout
+      )
+
+      if config.enable_reaper
+        @manager.configure_reaper(
+          enabled: true,
+          interval: config.reaper_interval,
+          idle_timeout: config.idle_timeout
+        )
+      end
+
+      @manager.start
+    end
+
+    def configured?
+      !@manager.nil? && !@manager.pool.nil?
+    end
+
+    def pool
+      raise NotConfiguredError unless configured?
+      @manager.pool
+    end
+
+    def shutdown!
+      @manager&.shutdown
+      @manager = nil
+    end
+
+    def reset!
+      shutdown!
+      @manager = nil
+    end
+
+    class Configuration
+      attr_accessor :redis_url, :pool_size, :pool_timeout,
+        :enable_reaper, :reaper_interval, :idle_timeout
+
+      def initialize
+        @redis_url = nil
+        @pool_size = 20
+        @pool_timeout = 5
+        @enable_reaper = true
+        @reaper_interval = 60
+        @idle_timeout = 300
+      end
+    end
+  end
+end

--- a/lib/model_context_protocol/server/redis_pool_manager.rb
+++ b/lib/model_context_protocol/server/redis_pool_manager.rb
@@ -1,0 +1,110 @@
+module ModelContextProtocol
+  class Server::RedisPoolManager
+    attr_reader :pool, :reaper_thread
+
+    def initialize(redis_url:, pool_size: 20, pool_timeout: 5)
+      @redis_url = redis_url
+      @pool_size = pool_size
+      @pool_timeout = pool_timeout
+      @pool = nil
+      @reaper_thread = nil
+      @reaper_config = {
+        enabled: false,
+        interval: 60,
+        idle_timeout: 300
+      }
+    end
+
+    def configure_reaper(enabled:, interval: 60, idle_timeout: 300)
+      @reaper_config = {
+        enabled: enabled,
+        interval: interval,
+        idle_timeout: idle_timeout
+      }
+    end
+
+    def start
+      validate!
+      create_pool
+      start_reaper if @reaper_config[:enabled]
+      true
+    end
+
+    def shutdown
+      stop_reaper
+      close_pool
+    end
+
+    def healthy?
+      return false unless @pool
+
+      @pool.with do |conn|
+        conn.ping == "PONG"
+      end
+    rescue
+      false
+    end
+
+    def reap_now
+      return unless @pool
+
+      @pool.reap(@reaper_config[:idle_timeout]) do |conn|
+        conn.close
+      end
+    end
+
+    def stats
+      return {} unless @pool
+
+      {
+        size: @pool.size,
+        available: @pool.available,
+        idle: @pool.instance_variable_get(:@idle_since)&.size || 0
+      }
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "redis_url is required" if @redis_url.nil? || @redis_url.empty?
+      raise ArgumentError, "pool_size must be positive" if @pool_size <= 0
+      raise ArgumentError, "pool_timeout must be positive" if @pool_timeout <= 0
+    end
+
+    def create_pool
+      @pool = ConnectionPool.new(size: @pool_size, timeout: @pool_timeout) do
+        Redis.new(url: @redis_url)
+      end
+    end
+
+    def close_pool
+      @pool&.shutdown { |conn| conn.close }
+      @pool = nil
+    end
+
+    def start_reaper
+      return if @reaper_thread&.alive?
+
+      @reaper_thread = Thread.new do
+        loop do
+          sleep @reaper_config[:interval]
+          begin
+            reap_now
+          rescue => e
+            warn "Redis reaper error: #{e.message}"
+          end
+        end
+      end
+
+      @reaper_thread.name = "MCP-Redis-Reaper"
+    end
+
+    def stop_reaper
+      return unless @reaper_thread&.alive?
+
+      @reaper_thread.kill
+      @reaper_thread.join(5)
+      @reaper_thread = nil
+    end
+  end
+end

--- a/lib/model_context_protocol/server/streamable_http_transport.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport.rb
@@ -4,6 +4,7 @@ require_relative "streamable_http_transport/stream_registry"
 require_relative "streamable_http_transport/notification_queue"
 require_relative "streamable_http_transport/event_counter"
 require_relative "streamable_http_transport/session_store"
+require_relative "streamable_http_transport/message_poller"
 
 module ModelContextProtocol
   class Server::StreamableHttpTransport
@@ -28,7 +29,7 @@ module ModelContextProtocol
       @redis = @redis_pool.checkout
       @require_sessions = transport_options.fetch(:require_sessions, false)
       @default_protocol_version = transport_options.fetch(:default_protocol_version, "2025-03-26")
-      @session_protocol_versions = {}  # Track protocol versions per session
+      @session_protocol_versions = {}
       @validate_origin = transport_options.fetch(:validate_origin, true)
       @allowed_origins = transport_options.fetch(:allowed_origins, ["http://localhost", "https://localhost", "http://127.0.0.1", "https://127.0.0.1"])
 
@@ -42,13 +43,19 @@ module ModelContextProtocol
       @notification_queue = NotificationQueue.new(@redis, @server_instance)
       @event_counter = EventCounter.new(@redis, @server_instance)
       @stream_monitor_thread = nil
+      @message_poller = MessagePoller.new(@redis, @stream_registry, @configuration.logger) do |stream, message|
+        send_to_stream(stream, message)
+      end
 
-      setup_redis_subscriber
+      start_message_poller
       start_stream_monitor
     end
 
     def shutdown
       @configuration.logger.info("Shutting down StreamableHttpTransport")
+
+      # Stop the message poller
+      @message_poller&.stop
 
       # Stop the stream monitor thread
       if @stream_monitor_thread&.alive?
@@ -392,13 +399,11 @@ module ModelContextProtocol
     end
 
     def monitor_streams
-      # Clean up any expired streams from Redis
       expired_sessions = @stream_registry.cleanup_expired_streams
       expired_sessions.each do |session_id|
         @session_store.mark_stream_inactive(session_id)
       end
 
-      # Send heartbeat for all local streams and check connectivity
       @stream_registry.get_all_local_streams.each do |session_id, stream|
         if stream_connected?(stream)
           send_ping_to_stream(stream)
@@ -438,7 +443,7 @@ module ModelContextProtocol
         end
       end
 
-      @session_store.route_message_to_session(session_id, data)
+      @session_store.queue_message_for_session(session_id, data)
     end
 
     def cleanup_session(session_id)
@@ -446,26 +451,8 @@ module ModelContextProtocol
       @session_store.cleanup_session(session_id)
     end
 
-    def setup_redis_subscriber
-      Thread.new do
-        @session_store.subscribe_to_server(@server_instance) do |data|
-          session_id = data["session_id"]
-          message = data["message"]
-
-          if @stream_registry.has_local_stream?(session_id)
-            stream = @stream_registry.get_local_stream(session_id)
-            begin
-              send_to_stream(stream, message)
-            rescue IOError, Errno::EPIPE, Errno::ECONNRESET
-              @stream_registry.unregister_stream(session_id)
-            end
-          end
-        end
-      rescue => e
-        @configuration.logger.error("Redis subscriber error", error: e.message, backtrace: e.backtrace.first(5))
-        sleep 5
-        retry
-      end
+    def start_message_poller
+      @message_poller.start
     end
 
     def has_active_streams?

--- a/lib/model_context_protocol/server/streamable_http_transport/message_poller.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport/message_poller.rb
@@ -1,0 +1,101 @@
+require_relative "session_message_queue"
+
+module ModelContextProtocol
+  class Server::StreamableHttpTransport
+    class MessagePoller
+      POLL_INTERVAL = 0.1  # 100ms
+      BATCH_SIZE = 100
+
+      def initialize(redis_client, stream_registry, logger, &message_delivery_block)
+        @redis = redis_client
+        @stream_registry = stream_registry
+        @logger = logger
+        @message_delivery_block = message_delivery_block
+        @running = false
+        @poll_thread = nil
+      end
+
+      def start
+        return if @running
+
+        @running = true
+        @poll_thread = Thread.new do
+          poll_loop
+        rescue => e
+          @logger.error("Message poller thread error", error: e.message, backtrace: e.backtrace.first(5))
+          sleep 1
+          retry if @running
+        end
+
+        @poll_thread.name = "MCP-MessagePoller" if @poll_thread.respond_to?(:name=)
+
+        @logger.debug("Message poller started")
+      end
+
+      def stop
+        @running = false
+
+        if @poll_thread&.alive?
+          @poll_thread.kill
+          @poll_thread.join(timeout: 5)
+        end
+
+        @poll_thread = nil
+        @logger.debug("Message poller stopped")
+      end
+
+      def running?
+        @running && @poll_thread&.alive?
+      end
+
+      private
+
+      def poll_loop
+        while @running
+          begin
+            poll_and_deliver_messages
+          rescue => e
+            @logger.error("Error in message polling", error: e.message)
+          end
+
+          sleep POLL_INTERVAL
+        end
+      end
+
+      def poll_and_deliver_messages
+        local_sessions = @stream_registry.get_all_local_streams.keys
+        return if local_sessions.empty?
+
+        local_sessions.each_slice(BATCH_SIZE) do |session_batch|
+          poll_sessions_batch(session_batch)
+        end
+      end
+
+      def poll_sessions_batch(session_ids)
+        session_ids.each do |session_id|
+          queue = SessionMessageQueue.new(@redis, session_id)
+          messages = queue.poll_messages
+
+          next if messages.empty?
+
+          stream = @stream_registry.get_local_stream(session_id)
+          next unless stream
+
+          messages.each do |message|
+            deliver_message_to_stream(stream, message, session_id)
+          end
+        end
+      end
+
+      def deliver_message_to_stream(stream, message, session_id)
+        @message_delivery_block&.call(stream, message)
+      rescue IOError, Errno::EPIPE, Errno::ECONNRESET
+        @stream_registry.unregister_stream(session_id)
+        @logger.debug("Unregistered disconnected stream", session_id: session_id)
+      rescue => e
+        @logger.error("Error delivering message to stream",
+          session_id: session_id, error: e.message)
+      end
+    end
+  end
+end

--- a/lib/model_context_protocol/server/streamable_http_transport/session_message_queue.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport/session_message_queue.rb
@@ -1,0 +1,120 @@
+require "json"
+require "securerandom"
+
+module ModelContextProtocol
+  class Server::StreamableHttpTransport
+    class SessionMessageQueue
+      QUEUE_KEY_PREFIX = "session_messages:"
+      LOCK_KEY_PREFIX = "session_lock:"
+      DEFAULT_TTL = 3600  # 1 hour
+      MAX_MESSAGES = 1000
+      LOCK_TIMEOUT = 5  # seconds
+
+      def initialize(redis_client, session_id, ttl: DEFAULT_TTL)
+        @redis = redis_client
+        @session_id = session_id
+        @queue_key = "#{QUEUE_KEY_PREFIX}#{session_id}"
+        @lock_key = "#{LOCK_KEY_PREFIX}#{session_id}"
+        @ttl = ttl
+      end
+
+      def push_message(message)
+        message_json = serialize_message(message)
+
+        @redis.multi do |multi|
+          multi.lpush(@queue_key, message_json)
+          multi.expire(@queue_key, @ttl)
+          multi.ltrim(@queue_key, 0, MAX_MESSAGES - 1)
+        end
+      end
+
+      def push_messages(messages)
+        return if messages.empty?
+
+        message_jsons = messages.map { |msg| serialize_message(msg) }
+
+        @redis.multi do |multi|
+          message_jsons.each do |json|
+            multi.lpush(@queue_key, json)
+          end
+          multi.expire(@queue_key, @ttl)
+          multi.ltrim(@queue_key, 0, MAX_MESSAGES - 1)
+        end
+      end
+
+      def poll_messages
+        lua_script = <<~LUA
+          local messages = redis.call('lrange', KEYS[1], 0, -1)
+          if #messages > 0 then
+            redis.call('del', KEYS[1])
+          end
+          return messages
+        LUA
+
+        messages = @redis.eval(lua_script, keys: [@queue_key])
+        return [] unless messages && !messages.empty?
+        messages.reverse.map { |json| deserialize_message(json) }
+      rescue
+        []
+      end
+
+      def peek_messages
+        messages = @redis.lrange(@queue_key, 0, -1)
+        messages.reverse.map { |json| deserialize_message(json) }
+      rescue
+        []
+      end
+
+      def has_messages?
+        @redis.exists(@queue_key) > 0
+      rescue
+        false
+      end
+
+      def message_count
+        @redis.llen(@queue_key)
+      rescue
+        0
+      end
+
+      def clear
+        @redis.del(@queue_key)
+      rescue
+      end
+
+      def with_lock(timeout: LOCK_TIMEOUT, &block)
+        lock_id = SecureRandom.hex(16)
+
+        acquired = @redis.set(@lock_key, lock_id, nx: true, ex: timeout)
+        return false unless acquired
+
+        begin
+          yield
+        ensure
+          lua_script = <<~LUA
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+              return redis.call("del", KEYS[1])
+            else
+              return 0
+            end
+          LUA
+          @redis.eval(lua_script, keys: [@lock_key], argv: [lock_id])
+        end
+
+        true
+      end
+
+      private
+
+      def serialize_message(message)
+        message.is_a?(String) ? message : message.to_json
+      end
+
+      def deserialize_message(json)
+        JSON.parse(json)
+      rescue JSON::ParserError
+        json
+      end
+    end
+  end
+end

--- a/model-context-protocol-rb.gemspec
+++ b/model-context-protocol-rb.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "json-schema", "~> 5.1"
   spec.add_dependency "addressable", "~> 2.8"
+  spec.add_dependency "redis", "~> 5.0"
+  spec.add_dependency "connection_pool", "~> 2.4"
 end

--- a/spec/lib/model_context_protocol/server/redis_client_proxy_spec.rb
+++ b/spec/lib/model_context_protocol/server/redis_client_proxy_spec.rb
@@ -1,0 +1,382 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::RedisClientProxy do
+  subject(:wrapper) { described_class.new(pool) }
+
+  let(:pool) { double("connection_pool") }
+  let(:redis_mock) { double("redis") }
+
+  before do
+    allow(pool).to receive(:with).and_yield(redis_mock)
+  end
+
+  describe "#initialize" do
+    it "stores the pool" do
+      expect(wrapper.instance_variable_get(:@pool)).to eq(pool)
+    end
+  end
+
+  describe "basic Redis operations" do
+    describe "#get" do
+      it "calls get on the Redis connection" do
+        expect(redis_mock).to receive(:get).with("test_key").and_return("test_value")
+
+        result = wrapper.get("test_key")
+        expect(result).to eq("test_value")
+      end
+    end
+
+    describe "#set" do
+      it "calls set on the Redis connection" do
+        expect(redis_mock).to receive(:set).with("test_key", "test_value").and_return("OK")
+
+        result = wrapper.set("test_key", "test_value")
+        expect(result).to eq("OK")
+      end
+
+      it "passes options to set" do
+        expect(redis_mock).to receive(:set).with("test_key", "test_value", nx: true, ex: 60).and_return("OK")
+
+        result = wrapper.set("test_key", "test_value", nx: true, ex: 60)
+        expect(result).to eq("OK")
+      end
+    end
+
+    describe "#del" do
+      it "calls del on the Redis connection with single key" do
+        expect(redis_mock).to receive(:del).with("test_key").and_return(1)
+
+        result = wrapper.del("test_key")
+        expect(result).to eq(1)
+      end
+
+      it "calls del on the Redis connection with multiple keys" do
+        expect(redis_mock).to receive(:del).with("key1", "key2", "key3").and_return(3)
+
+        result = wrapper.del("key1", "key2", "key3")
+        expect(result).to eq(3)
+      end
+    end
+
+    describe "#exists" do
+      it "calls exists on the Redis connection" do
+        expect(redis_mock).to receive(:exists).with("test_key").and_return(1)
+
+        result = wrapper.exists("test_key")
+        expect(result).to eq(1)
+      end
+
+      it "handles multiple keys" do
+        expect(redis_mock).to receive(:exists).with("key1", "key2").and_return(2)
+
+        result = wrapper.exists("key1", "key2")
+        expect(result).to eq(2)
+      end
+    end
+
+    describe "#expire" do
+      it "calls expire on the Redis connection" do
+        expect(redis_mock).to receive(:expire).with("test_key", 60).and_return(1)
+
+        result = wrapper.expire("test_key", 60)
+        expect(result).to eq(1)
+      end
+    end
+
+    describe "#ttl" do
+      it "calls ttl on the Redis connection" do
+        expect(redis_mock).to receive(:ttl).with("test_key").and_return(60)
+
+        result = wrapper.ttl("test_key")
+        expect(result).to eq(60)
+      end
+    end
+  end
+
+  describe "hash operations" do
+    describe "#hget" do
+      it "calls hget on the Redis connection" do
+        expect(redis_mock).to receive(:hget).with("hash_key", "field").and_return("value")
+
+        result = wrapper.hget("hash_key", "field")
+        expect(result).to eq("value")
+      end
+    end
+
+    describe "#hset" do
+      it "calls hset on the Redis connection" do
+        expect(redis_mock).to receive(:hset).with("hash_key", "field", "value").and_return(1)
+
+        result = wrapper.hset("hash_key", "field", "value")
+        expect(result).to eq(1)
+      end
+
+      it "handles multiple field-value pairs" do
+        expect(redis_mock).to receive(:hset).with("hash_key", "field1", "value1", "field2", "value2").and_return(2)
+
+        result = wrapper.hset("hash_key", "field1", "value1", "field2", "value2")
+        expect(result).to eq(2)
+      end
+    end
+
+    describe "#hgetall" do
+      it "calls hgetall on the Redis connection" do
+        hash_data = {"field1" => "value1", "field2" => "value2"}
+        expect(redis_mock).to receive(:hgetall).with("hash_key").and_return(hash_data)
+
+        result = wrapper.hgetall("hash_key")
+        expect(result).to eq(hash_data)
+      end
+    end
+  end
+
+  describe "list operations" do
+    describe "#lpush" do
+      it "calls lpush on the Redis connection with single value" do
+        expect(redis_mock).to receive(:lpush).with("list_key", "value").and_return(1)
+
+        result = wrapper.lpush("list_key", "value")
+        expect(result).to eq(1)
+      end
+
+      it "calls lpush on the Redis connection with multiple values" do
+        expect(redis_mock).to receive(:lpush).with("list_key", "value1", "value2").and_return(2)
+
+        result = wrapper.lpush("list_key", "value1", "value2")
+        expect(result).to eq(2)
+      end
+    end
+
+    describe "#rpop" do
+      it "calls rpop on the Redis connection" do
+        expect(redis_mock).to receive(:rpop).with("list_key").and_return("value")
+
+        result = wrapper.rpop("list_key")
+        expect(result).to eq("value")
+      end
+    end
+
+    describe "#lrange" do
+      it "calls lrange on the Redis connection" do
+        list_data = ["value1", "value2", "value3"]
+        expect(redis_mock).to receive(:lrange).with("list_key", 0, -1).and_return(list_data)
+
+        result = wrapper.lrange("list_key", 0, -1)
+        expect(result).to eq(list_data)
+      end
+    end
+
+    describe "#llen" do
+      it "calls llen on the Redis connection" do
+        expect(redis_mock).to receive(:llen).with("list_key").and_return(3)
+
+        result = wrapper.llen("list_key")
+        expect(result).to eq(3)
+      end
+    end
+
+    describe "#ltrim" do
+      it "calls ltrim on the Redis connection" do
+        expect(redis_mock).to receive(:ltrim).with("list_key", 0, 99).and_return("OK")
+
+        result = wrapper.ltrim("list_key", 0, 99)
+        expect(result).to eq("OK")
+      end
+    end
+  end
+
+  describe "counter operations" do
+    describe "#incr" do
+      it "calls incr on the Redis connection" do
+        expect(redis_mock).to receive(:incr).with("counter_key").and_return(1)
+
+        result = wrapper.incr("counter_key")
+        expect(result).to eq(1)
+      end
+    end
+
+    describe "#decr" do
+      it "calls decr on the Redis connection" do
+        expect(redis_mock).to receive(:decr).with("counter_key").and_return(0)
+
+        result = wrapper.decr("counter_key")
+        expect(result).to eq(0)
+      end
+    end
+  end
+
+  describe "key pattern operations" do
+    describe "#keys" do
+      it "calls keys on the Redis connection" do
+        key_list = ["key1", "key2", "key3"]
+        expect(redis_mock).to receive(:keys).with("test:*").and_return(key_list)
+
+        result = wrapper.keys("test:*")
+        expect(result).to eq(key_list)
+      end
+    end
+  end
+
+  describe "multi-get operation" do
+    describe "#mget" do
+      it "calls mget on the Redis connection" do
+        values = ["value1", "value2", nil]
+        expect(redis_mock).to receive(:mget).with("key1", "key2", "key3").and_return(values)
+
+        result = wrapper.mget("key1", "key2", "key3")
+        expect(result).to eq(values)
+      end
+    end
+  end
+
+  describe "Lua script evaluation" do
+    describe "#eval" do
+      it "calls eval on the Redis connection with script only" do
+        script = "return redis.call('get', KEYS[1])"
+        expect(redis_mock).to receive(:eval).with(script, keys: [], argv: []).and_return("result")
+
+        result = wrapper.eval(script)
+        expect(result).to eq("result")
+      end
+
+      it "calls eval on the Redis connection with keys and argv" do
+        script = "return redis.call('set', KEYS[1], ARGV[1])"
+        expect(redis_mock).to receive(:eval).with(script, keys: ["test_key"], argv: ["test_value"]).and_return("OK")
+
+        result = wrapper.eval(script, keys: ["test_key"], argv: ["test_value"])
+        expect(result).to eq("OK")
+      end
+    end
+  end
+
+  describe "utility methods" do
+    describe "#ping" do
+      it "calls ping on the Redis connection" do
+        expect(redis_mock).to receive(:ping).and_return("PONG")
+
+        result = wrapper.ping
+        expect(result).to eq("PONG")
+      end
+    end
+
+    describe "#flushdb" do
+      it "calls flushdb on the Redis connection" do
+        expect(redis_mock).to receive(:flushdb).and_return("OK")
+
+        result = wrapper.flushdb
+        expect(result).to eq("OK")
+      end
+    end
+  end
+
+  describe "transaction support" do
+    describe "#multi" do
+      let(:multi_mock) { double("redis_multi") }
+      let(:multi_wrapper) { double("redis_multi_wrapper") }
+
+      it "creates a transaction and wraps the multi object" do
+        expect(redis_mock).to receive(:multi).and_yield(multi_mock).and_return(["OK", "OK"])
+        expect(ModelContextProtocol::Server::RedisClientProxy::RedisMultiWrapper).to receive(:new).with(multi_mock).and_return(multi_wrapper)
+
+        result = wrapper.multi do |multi|
+          expect(multi).to eq(multi_wrapper)
+        end
+
+        expect(result).to eq(["OK", "OK"])
+      end
+    end
+  end
+
+  describe "pipeline support" do
+    describe "#pipelined" do
+      let(:pipeline_mock) { double("redis_pipeline") }
+      let(:pipeline_wrapper) { double("redis_pipeline_wrapper") }
+
+      it "creates a pipeline and wraps the pipeline object" do
+        expect(redis_mock).to receive(:pipelined).and_yield(pipeline_mock).and_return(["OK", "OK"])
+        expect(ModelContextProtocol::Server::RedisClientProxy::RedisMultiWrapper).to receive(:new).with(pipeline_mock).and_return(pipeline_wrapper)
+
+        result = wrapper.pipelined do |pipeline|
+          expect(pipeline).to eq(pipeline_wrapper)
+        end
+
+        expect(result).to eq(["OK", "OK"])
+      end
+    end
+  end
+
+  describe "connection pool interaction" do
+    it "uses the pool for each operation" do
+      expect(pool).to receive(:with).exactly(3).times.and_yield(redis_mock)
+      expect(redis_mock).to receive(:get).with("key1").and_return("value1")
+      expect(redis_mock).to receive(:get).with("key2").and_return("value2")
+      expect(redis_mock).to receive(:get).with("key3").and_return("value3")
+
+      wrapper.get("key1")
+      wrapper.get("key2")
+      wrapper.get("key3")
+    end
+
+    it "handles pool exceptions gracefully" do
+      allow(pool).to receive(:with).and_raise(StandardError.new("Pool exhausted"))
+
+      expect { wrapper.get("test_key") }.to raise_error(StandardError, "Pool exhausted")
+    end
+  end
+
+  describe ModelContextProtocol::Server::RedisClientProxy::RedisMultiWrapper do
+    subject(:multi_wrapper) { described_class.new(multi_mock) }
+
+    let(:multi_mock) { double("redis_multi") }
+
+    describe "#initialize" do
+      it "stores the multi object" do
+        expect(multi_wrapper.instance_variable_get(:@multi)).to eq(multi_mock)
+      end
+    end
+
+    describe "method delegation" do
+      it "delegates method calls to the underlying multi object" do
+        expect(multi_mock).to receive(:set).with("key", "value").and_return("QUEUED")
+
+        result = multi_wrapper.set("key", "value")
+        expect(result).to eq("QUEUED")
+      end
+
+      it "delegates method calls with keyword arguments" do
+        expect(multi_mock).to receive(:set).with("key", "value", nx: true).and_return("QUEUED")
+
+        result = multi_wrapper.set("key", "value", nx: true)
+        expect(result).to eq("QUEUED")
+      end
+
+      it "delegates method calls with blocks" do
+        block = proc { "test" }
+        expect(multi_mock).to receive(:eval).with("script", &block).and_return("QUEUED")
+
+        result = multi_wrapper.eval("script", &block)
+        expect(result).to eq("QUEUED")
+      end
+    end
+
+    describe "#respond_to_missing?" do
+      it "returns true for methods the multi object responds to" do
+        allow(multi_mock).to receive(:respond_to?).with(:set, false).and_return(true)
+
+        expect(multi_wrapper.respond_to?(:set)).to be true
+      end
+
+      it "returns false for methods the multi object doesn't respond to" do
+        allow(multi_mock).to receive(:respond_to?).with(:nonexistent_method, false).and_return(false)
+
+        expect(multi_wrapper.respond_to?(:nonexistent_method)).to be false
+      end
+
+      it "passes include_private parameter" do
+        expect(multi_mock).to receive(:respond_to?).with(:private_method, true).and_return(true)
+
+        expect(multi_wrapper.respond_to?(:private_method, true)).to be true
+      end
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/redis_config_spec.rb
+++ b/spec/lib/model_context_protocol/server/redis_config_spec.rb
@@ -1,0 +1,204 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::RedisConfig do
+  let(:redis_url) { "redis://localhost:6379/15" }
+  let(:manager_mock) { instance_double(ModelContextProtocol::Server::RedisPoolManager) }
+
+  before(:each) do
+    described_class.instance_variable_set(:@singleton__instance__, nil) if described_class.instance_variable_defined?(:@singleton__instance__)
+
+    allow(ModelContextProtocol::Server::RedisPoolManager).to receive(:new).and_return(manager_mock)
+    allow(manager_mock).to receive(:configure_reaper)
+    allow(manager_mock).to receive(:start).and_return(true)
+    allow(manager_mock).to receive(:shutdown)
+    allow(manager_mock).to receive(:pool).and_return(double("pool"))
+  end
+
+  after(:each) do
+    begin
+      described_class.instance.reset!
+    rescue
+      nil
+    end
+
+    described_class.instance_variable_set(:@singleton__instance__, nil) if described_class.instance_variable_defined?(:@singleton__instance__)
+  end
+
+  describe ".configure" do
+    it "yields configuration object" do
+      yielded_config = nil
+      described_class.configure do |config|
+        config.redis_url = redis_url
+        yielded_config = config
+      end
+
+      expect(yielded_config).to be_a(ModelContextProtocol::Server::RedisConfig::Configuration)
+    end
+
+    it "creates and starts pool manager" do
+      expect(ModelContextProtocol::Server::RedisPoolManager).to receive(:new).with(
+        redis_url: redis_url,
+        pool_size: 20,
+        pool_timeout: 5
+      ).and_return(manager_mock)
+      expect(manager_mock).to receive(:start)
+
+      described_class.configure do |c|
+        c.redis_url = redis_url
+      end
+
+      expect(described_class.configured?).to be true
+    end
+
+    it "configures reaper when enabled" do
+      expect(manager_mock).to receive(:configure_reaper).with(
+        enabled: true,
+        interval: 30,
+        idle_timeout: 120
+      )
+
+      described_class.configure do |c|
+        c.redis_url = redis_url
+        c.enable_reaper = true
+        c.reaper_interval = 30
+        c.idle_timeout = 120
+      end
+    end
+
+    it "does not configure reaper when disabled" do
+      expect(manager_mock).not_to receive(:configure_reaper)
+
+      described_class.configure do |c|
+        c.redis_url = redis_url
+        c.enable_reaper = false
+      end
+    end
+  end
+
+  describe ".configured?" do
+    context "when not configured" do
+      it "returns false" do
+        expect(described_class.configured?).to be false
+      end
+    end
+
+    context "when configured" do
+      before do
+        described_class.configure do |c|
+          c.redis_url = redis_url
+        end
+      end
+
+      it "returns true" do
+        expect(described_class.configured?).to be true
+      end
+    end
+  end
+
+  describe ".pool" do
+    context "when configured" do
+      before do
+        described_class.configure do |c|
+          c.redis_url = redis_url
+        end
+      end
+
+      it "returns the connection pool" do
+        mock_pool = double("pool")
+        allow(manager_mock).to receive(:pool).and_return(mock_pool)
+        expect(described_class.pool).to eq(mock_pool)
+      end
+    end
+
+    context "when not configured" do
+      it "raises NotConfiguredError" do
+        expect { described_class.pool }.to raise_error(
+          ModelContextProtocol::Server::RedisConfig::NotConfiguredError,
+          /Redis not configured/
+        )
+      end
+    end
+  end
+
+  describe ".shutdown!" do
+    context "when configured" do
+      before do
+        described_class.configure do |c|
+          c.redis_url = redis_url
+        end
+      end
+
+      it "shuts down the manager" do
+        expect(manager_mock).to receive(:shutdown)
+        described_class.shutdown!
+      end
+    end
+
+    context "when not configured" do
+      it "does not raise error" do
+        expect { described_class.shutdown! }.not_to raise_error
+      end
+    end
+  end
+
+  describe "Configuration class" do
+    let(:configuration) { described_class::Configuration.new }
+
+    describe "#initialize" do
+      it "sets default values" do
+        aggregate_failures do
+          expect(configuration.redis_url).to be_nil
+          expect(configuration.pool_size).to eq(20)
+          expect(configuration.pool_timeout).to eq(5)
+          expect(configuration.enable_reaper).to be true
+          expect(configuration.reaper_interval).to eq(60)
+          expect(configuration.idle_timeout).to eq(300)
+        end
+      end
+    end
+
+    describe "attribute setters" do
+      it "allows setting redis_url" do
+        configuration.redis_url = "redis://test:6379"
+        expect(configuration.redis_url).to eq("redis://test:6379")
+      end
+
+      it "allows setting pool_size" do
+        configuration.pool_size = 10
+        expect(configuration.pool_size).to eq(10)
+      end
+
+      it "allows setting pool_timeout" do
+        configuration.pool_timeout = 3
+        expect(configuration.pool_timeout).to eq(3)
+      end
+
+      it "allows setting enable_reaper" do
+        configuration.enable_reaper = false
+        expect(configuration.enable_reaper).to be false
+      end
+
+      it "allows setting reaper_interval" do
+        configuration.reaper_interval = 120
+        expect(configuration.reaper_interval).to eq(120)
+      end
+
+      it "allows setting idle_timeout" do
+        configuration.idle_timeout = 600
+        expect(configuration.idle_timeout).to eq(600)
+      end
+    end
+  end
+
+  describe "error handling" do
+    it "propagates validation errors from manager" do
+      allow(manager_mock).to receive(:start).and_raise(ArgumentError, "redis_url is required")
+
+      expect {
+        described_class.configure do |c|
+          c.redis_url = nil
+        end
+      }.to raise_error(ArgumentError, /redis_url is required/)
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/redis_pool_manager_spec.rb
+++ b/spec/lib/model_context_protocol/server/redis_pool_manager_spec.rb
@@ -1,0 +1,270 @@
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::RedisPoolManager do
+  subject(:manager) { described_class.new(redis_url:, pool_size:, pool_timeout:) }
+
+  let(:redis_url) { "redis://localhost:6379/15" }
+  let(:pool_size) { 5 }
+  let(:pool_timeout) { 2 }
+
+  describe "#initialize" do
+    it "stores configuration" do
+      aggregate_failures do
+        expect(manager.instance_variable_get(:@redis_url)).to eq(redis_url)
+        expect(manager.instance_variable_get(:@pool_size)).to eq(5)
+        expect(manager.instance_variable_get(:@pool_timeout)).to eq(2)
+      end
+    end
+
+    it "does not create pool immediately" do
+      expect(manager.pool).to be_nil
+    end
+
+    it "sets default reaper configuration" do
+      reaper_config = manager.instance_variable_get(:@reaper_config)
+      expect(reaper_config).to eq({
+        enabled: false,
+        interval: 60,
+        idle_timeout: 300
+      })
+    end
+  end
+
+  describe "#configure_reaper" do
+    it "updates reaper configuration" do
+      manager.configure_reaper(
+        enabled: true,
+        interval: 30,
+        idle_timeout: 120
+      )
+
+      reaper_config = manager.instance_variable_get(:@reaper_config)
+      expect(reaper_config).to eq({
+        enabled: true,
+        interval: 30,
+        idle_timeout: 120
+      })
+    end
+  end
+
+  describe "#start" do
+    context "with valid configuration" do
+      it "creates the connection pool" do
+        manager.start
+        expect(manager.pool).to be_a(ConnectionPool)
+      end
+
+      it "creates pool with correct size" do
+        manager.start
+        expect(manager.pool.size).to eq(5)
+      end
+
+      it "returns true on success" do
+        expect(manager.start).to be true
+      end
+    end
+
+    context "with invalid configuration" do
+      let(:redis_url) { nil }
+
+      it "raises ArgumentError for missing redis_url" do
+        expect { manager.start }.to raise_error(ArgumentError, /redis_url is required/)
+      end
+    end
+
+    context "with negative pool_size" do
+      let(:pool_size) { -1 }
+
+      it "raises ArgumentError" do
+        expect { manager.start }.to raise_error(ArgumentError, /pool_size must be positive/)
+      end
+    end
+
+    context "with negative pool_timeout" do
+      let(:pool_timeout) { -1 }
+
+      it "raises ArgumentError" do
+        expect { manager.start }.to raise_error(ArgumentError, /pool_timeout must be positive/)
+      end
+    end
+
+    context "with reaper enabled" do
+      before do
+        manager.configure_reaper(enabled: true, interval: 1)
+      end
+
+      it "starts reaper thread" do
+        manager.start
+
+        aggregate_failures do
+          expect(manager.reaper_thread).to be_a(Thread)
+          expect(manager.reaper_thread).to be_alive
+        end
+
+        manager.shutdown
+      end
+
+      it "names the reaper thread" do
+        manager.start
+
+        expect(manager.reaper_thread.name).to eq("MCP-Redis-Reaper")
+
+        manager.shutdown
+      end
+    end
+  end
+
+  describe "#shutdown" do
+    before do
+      manager.start
+    end
+
+    it "closes the pool" do
+      conn = double("conn")
+      allow(conn).to receive(:close)
+
+      expect(manager.pool).to receive(:shutdown).and_yield(conn)
+
+      manager.shutdown
+
+      expect(manager.pool).to be_nil
+    end
+
+    it "stops reaper thread if running" do
+      manager.configure_reaper(enabled: true)
+      manager.start
+
+      thread = manager.reaper_thread
+      expect(thread).to be_alive
+
+      manager.shutdown
+
+      expect(thread.alive?).to be_falsey
+    end
+  end
+
+  describe "#healthy?" do
+    context "when pool does not exist" do
+      it "returns false" do
+        expect(manager.healthy?).to be false
+      end
+    end
+
+    context "when pool exists" do
+      before do
+        manager.start
+      end
+
+      context "and Redis responds to ping" do
+        it "returns true" do
+          expect(manager.healthy?).to be true
+        end
+      end
+
+      context "and Redis connection fails" do
+        before do
+          redis_mock = double("redis")
+          allow(redis_mock).to receive(:ping).and_raise(StandardError.new("Connection failed"))
+          allow(manager.pool).to receive(:with).and_yield(redis_mock)
+        end
+
+        it "returns false" do
+          expect(manager.healthy?).to be false
+        end
+      end
+
+      context "and Redis returns unexpected response" do
+        before do
+          redis_mock = double("redis")
+          allow(redis_mock).to receive(:ping).and_return("UNEXPECTED")
+          allow(manager.pool).to receive(:with).and_yield(redis_mock)
+        end
+
+        it "returns false" do
+          expect(manager.healthy?).to be false
+        end
+      end
+    end
+  end
+
+  describe "#reap_now" do
+    context "when pool does not exist" do
+      it "returns without error" do
+        expect { manager.reap_now }.not_to raise_error
+      end
+    end
+
+    context "when pool exists" do
+      before do
+        manager.start
+      end
+
+      it "calls reap on the pool with default timeout" do
+        expect(manager.pool).to receive(:reap).with(300)
+        manager.reap_now
+      end
+
+      it "uses configured idle timeout" do
+        manager.configure_reaper(enabled: false, idle_timeout: 600)
+        expect(manager.pool).to receive(:reap).with(600)
+        manager.reap_now
+      end
+
+      it "yields connections to close block" do
+        conn = double("connection")
+        expect(conn).to receive(:close)
+
+        expect(manager.pool).to receive(:reap).with(300).and_yield(conn)
+        manager.reap_now
+      end
+    end
+  end
+
+  describe "#stats" do
+    context "when pool does not exist" do
+      it "returns empty hash" do
+        expect(manager.stats).to eq({})
+      end
+    end
+
+    context "when pool exists" do
+      before do
+        manager.start
+      end
+
+      it "returns pool statistics" do
+        stats = manager.stats
+        aggregate_failures do
+          expect(stats).to include(:size, :available, :idle)
+          expect(stats[:size]).to eq(5)
+          expect(stats[:available]).to eq(5)
+          expect(stats[:idle]).to be >= 0
+        end
+      end
+    end
+  end
+
+  describe "reaper thread behavior" do
+    it "reaps connections at specified intervals" do
+      manager.configure_reaper(enabled: true, interval: 0.1)
+
+      expect(manager).to receive(:reap_now).at_least(2).times
+
+      manager.start
+      sleep 0.25
+      manager.shutdown
+    end
+
+    it "handles reaper errors gracefully" do
+      manager.configure_reaper(enabled: true, interval: 0.1)
+
+      allow(manager).to receive(:reap_now).and_raise("Reaper error")
+
+      expect {
+        manager.start
+        sleep 0.15
+        manager.shutdown
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/streamable_http_transport/message_poller_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport/message_poller_spec.rb
@@ -1,0 +1,463 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport::MessagePoller do
+  let(:redis) { MockRedis.new }
+  let(:stream_registry) { double("StreamRegistry") }
+  let(:logger) { double("Logger") }
+  let(:message_delivery_block) { double("MessageDeliveryBlock") }
+
+  let(:poller) do
+    described_class.new(redis, stream_registry, logger) do |stream, message|
+      message_delivery_block.call(stream, message)
+    end
+  end
+
+  before do
+    redis.flushdb
+    allow(logger).to receive(:debug)
+    allow(logger).to receive(:error)
+    allow(stream_registry).to receive(:get_all_local_streams).and_return({})
+  end
+
+  describe "#initialize" do
+    it "creates a poller with the correct configuration" do
+      aggregate_failures do
+        expect(poller.instance_variable_get(:@redis)).to eq(redis)
+        expect(poller.instance_variable_get(:@stream_registry)).to eq(stream_registry)
+        expect(poller.instance_variable_get(:@logger)).to eq(logger)
+        expect(poller.instance_variable_get(:@running)).to eq(false)
+        expect(poller.instance_variable_get(:@poll_thread)).to be_nil
+      end
+    end
+
+    it "stores the message delivery block" do
+      expect(poller.instance_variable_get(:@message_delivery_block)).to be_a(Proc)
+    end
+  end
+
+  describe "#start" do
+    let(:mock_thread) { double("Thread", name: nil, alive?: true) }
+
+    before do
+      allow(Thread).to receive(:new) do |&block|
+        mock_thread
+      end
+      allow(mock_thread).to receive(:name=)
+    end
+
+    it "starts the polling thread" do
+      expect(Thread).to receive(:new)
+
+      poller.start
+
+      aggregate_failures do
+        expect(poller.instance_variable_get(:@running)).to eq(true)
+        expect(poller.instance_variable_get(:@poll_thread)).to eq(mock_thread)
+      end
+    end
+
+    it "logs debug message when started" do
+      expect(logger).to receive(:debug).with("Message poller started")
+
+      poller.start
+    end
+
+    it "sets thread name if possible" do
+      expect(mock_thread).to receive(:name=).with("MCP-MessagePoller")
+
+      poller.start
+    end
+
+    it "handles thread name setting gracefully if not supported" do
+      allow(mock_thread).to receive(:respond_to?).with(:name=).and_return(false)
+
+      aggregate_failures do
+        expect(mock_thread).not_to receive(:name=)
+        expect { poller.start }.not_to raise_error
+      end
+    end
+
+    it "does not start if already running" do
+      poller.instance_variable_set(:@running, true)
+
+      expect(Thread).not_to receive(:new)
+
+      poller.start
+    end
+
+    context "when thread encounters error" do
+      let(:failing_thread) do
+        double("Thread").tap do |thread|
+          allow(thread).to receive(:name=)
+          allow(thread).to receive(:name)
+          allow(thread).to receive(:alive?).and_return(true)
+        end
+      end
+
+      before do
+        allow(Thread).to receive(:new) do |&block|
+          allow(failing_thread).to receive(:join) do
+            poller.send(:poll_and_deliver_messages) if poller.respond_to?(:poll_and_deliver_messages, true)
+          rescue => e
+            logger.error("Message poller thread error", error: e.message, backtrace: e.backtrace&.first(5))
+          end
+          failing_thread
+        end
+      end
+
+      it "logs errors and continues running" do
+        allow(poller).to receive(:poll_and_deliver_messages).and_raise("Test error")
+
+        expect(logger).to receive(:error).with("Message poller thread error",
+          hash_including(error: "Test error"))
+
+        poller.start
+        failing_thread.join
+      end
+    end
+  end
+
+  describe "#stop" do
+    let(:mock_thread) { double("Thread", alive?: true, kill: nil, join: nil, name: nil) }
+
+    before do
+      poller.instance_variable_set(:@running, true)
+      poller.instance_variable_set(:@poll_thread, mock_thread)
+      allow(mock_thread).to receive(:name=)
+    end
+
+    it "stops the polling thread" do
+      aggregate_failures do
+        expect(mock_thread).to receive(:kill)
+        expect(mock_thread).to receive(:join).with(timeout: 5)
+      end
+
+      poller.stop
+
+      aggregate_failures do
+        expect(poller.instance_variable_get(:@running)).to eq(false)
+        expect(poller.instance_variable_get(:@poll_thread)).to be_nil
+      end
+    end
+
+    it "logs debug message when stopped" do
+      expect(logger).to receive(:debug).with("Message poller stopped")
+
+      poller.stop
+    end
+
+    it "handles case when thread is not alive" do
+      allow(mock_thread).to receive(:alive?).and_return(false)
+
+      aggregate_failures do
+        expect(mock_thread).not_to receive(:kill)
+        expect(mock_thread).not_to receive(:join)
+      end
+
+      poller.stop
+    end
+
+    it "handles case when thread is nil" do
+      poller.instance_variable_set(:@poll_thread, nil)
+
+      expect { poller.stop }.not_to raise_error
+    end
+  end
+
+  describe "#running?" do
+    context "when not started" do
+      it "returns false" do
+        expect(poller.running?).to eq(false)
+      end
+    end
+
+    context "when started" do
+      let(:mock_thread) { double("Thread", alive?: true, name: nil) }
+
+      before do
+        poller.instance_variable_set(:@running, true)
+        poller.instance_variable_set(:@poll_thread, mock_thread)
+        allow(mock_thread).to receive(:name=)
+      end
+
+      it "returns true when running and thread is alive" do
+        expect(poller.running?).to eq(true)
+      end
+
+      it "returns false when marked as not running" do
+        poller.instance_variable_set(:@running, false)
+        expect(poller.running?).to eq(false)
+      end
+
+      it "returns false when thread is not alive" do
+        allow(mock_thread).to receive(:alive?).and_return(false)
+        expect(poller.running?).to eq(false)
+      end
+    end
+  end
+
+  describe "#poll_and_deliver_messages" do
+    context "when no local streams exist" do
+      before do
+        allow(stream_registry).to receive(:get_all_local_streams).and_return({})
+      end
+
+      it "returns early without polling" do
+        expect(poller).not_to receive(:poll_sessions_batch)
+        poller.send(:poll_and_deliver_messages)
+      end
+    end
+
+    context "when local streams exist" do
+      let(:session_id_1) { "session-1" }
+      let(:session_id_2) { "session-2" }
+      let(:stream_1) { double("Stream1") }
+      let(:stream_2) { double("Stream2") }
+
+      before do
+        allow(stream_registry).to receive(:get_all_local_streams).and_return({
+          session_id_1 => stream_1,
+          session_id_2 => stream_2
+        })
+      end
+
+      it "polls messages for all local sessions" do
+        expect(poller).to receive(:poll_sessions_batch).with([session_id_1, session_id_2])
+        poller.send(:poll_and_deliver_messages)
+      end
+
+      context "with large number of sessions" do
+        let(:many_sessions) do
+          {}.tap do |sessions|
+            150.times { |i| sessions["session-#{i}"] = double("Stream#{i}") }
+          end
+        end
+
+        before do
+          allow(stream_registry).to receive(:get_all_local_streams).and_return(many_sessions)
+        end
+
+        it "processes sessions in batches" do
+          aggregate_failures do
+            expect(poller).to receive(:poll_sessions_batch).with(many_sessions.keys[0..99])
+            expect(poller).to receive(:poll_sessions_batch).with(many_sessions.keys[100..149])
+          end
+
+          poller.send(:poll_and_deliver_messages)
+        end
+      end
+    end
+  end
+
+  describe "#poll_sessions_batch" do
+    let(:session_id_1) { "session-1" }
+    let(:session_id_2) { "session-2" }
+    let(:stream_1) { double("Stream1") }
+    let(:stream_2) { double("Stream2") }
+    let(:message_1) { {"method" => "test1", "params" => {"data" => "hello1"}} }
+    let(:message_2) { {"method" => "test2", "params" => {"data" => "hello2"}} }
+
+    before do
+      allow(stream_registry).to receive(:get_local_stream).with(session_id_1).and_return(stream_1)
+      allow(stream_registry).to receive(:get_local_stream).with(session_id_2).and_return(stream_2)
+    end
+
+    context "when sessions have messages" do
+      before do
+        queue_1 = ModelContextProtocol::Server::StreamableHttpTransport::SessionMessageQueue.new(redis, session_id_1)
+        queue_1.push_message(message_1)
+
+        queue_2 = ModelContextProtocol::Server::StreamableHttpTransport::SessionMessageQueue.new(redis, session_id_2)
+        queue_2.push_message(message_2)
+      end
+
+      it "delivers messages to their respective streams" do
+        aggregate_failures do
+          expect(message_delivery_block).to receive(:call).with(stream_1, message_1)
+          expect(message_delivery_block).to receive(:call).with(stream_2, message_2)
+        end
+
+        poller.send(:poll_sessions_batch, [session_id_1, session_id_2])
+      end
+    end
+
+    context "when sessions have no messages" do
+      it "does not attempt delivery" do
+        expect(message_delivery_block).not_to receive(:call)
+
+        poller.send(:poll_sessions_batch, [session_id_1, session_id_2])
+      end
+    end
+
+    context "when stream does not exist for session" do
+      before do
+        allow(stream_registry).to receive(:get_local_stream).with(session_id_1).and_return(nil)
+
+        queue_1 = ModelContextProtocol::Server::StreamableHttpTransport::SessionMessageQueue.new(redis, session_id_1)
+        queue_1.push_message(message_1)
+      end
+
+      it "skips delivery for sessions without streams" do
+        expect(message_delivery_block).not_to receive(:call)
+
+        poller.send(:poll_sessions_batch, [session_id_1])
+      end
+    end
+
+    context "when multiple messages exist for a session" do
+      let(:message_3) { {"method" => "test3", "params" => {"data" => "hello3"}} }
+
+      before do
+        queue_1 = ModelContextProtocol::Server::StreamableHttpTransport::SessionMessageQueue.new(redis, session_id_1)
+        queue_1.push_message(message_1)
+        queue_1.push_message(message_3)
+      end
+
+      it "delivers all messages in order" do
+        aggregate_failures do
+          expect(message_delivery_block).to receive(:call).with(stream_1, message_1).ordered
+          expect(message_delivery_block).to receive(:call).with(stream_1, message_3).ordered
+        end
+
+        poller.send(:poll_sessions_batch, [session_id_1])
+      end
+    end
+  end
+
+  describe "#deliver_message_to_stream" do
+    let(:stream) { double("Stream") }
+    let(:message) { {"method" => "test", "params" => {"data" => "hello"}} }
+    let(:session_id) { "test-session" }
+
+    context "when delivery succeeds" do
+      it "calls the message delivery block" do
+        expect(message_delivery_block).to receive(:call).with(stream, message)
+
+        poller.send(:deliver_message_to_stream, stream, message, session_id)
+      end
+    end
+
+    context "when message delivery block is nil" do
+      let(:poller_without_block) do
+        described_class.new(redis, stream_registry, logger)
+      end
+
+      it "handles gracefully" do
+        expect { poller_without_block.send(:deliver_message_to_stream, stream, message, session_id) }.not_to raise_error
+      end
+    end
+
+    context "when stream is disconnected" do
+      before do
+        allow(message_delivery_block).to receive(:call).and_raise(IOError)
+      end
+
+      it "unregisters the stream" do
+        aggregate_failures do
+          expect(stream_registry).to receive(:unregister_stream).with(session_id)
+          expect(logger).to receive(:debug).with("Unregistered disconnected stream", session_id: session_id)
+        end
+
+        poller.send(:deliver_message_to_stream, stream, message, session_id)
+      end
+
+      it "handles EPIPE errors" do
+        allow(message_delivery_block).to receive(:call).and_raise(Errno::EPIPE)
+
+        expect(stream_registry).to receive(:unregister_stream).with(session_id)
+
+        poller.send(:deliver_message_to_stream, stream, message, session_id)
+      end
+
+      it "handles ECONNRESET errors" do
+        allow(message_delivery_block).to receive(:call).and_raise(Errno::ECONNRESET)
+
+        expect(stream_registry).to receive(:unregister_stream).with(session_id)
+
+        poller.send(:deliver_message_to_stream, stream, message, session_id)
+      end
+    end
+
+    context "when other errors occur" do
+      before do
+        allow(message_delivery_block).to receive(:call).and_raise(StandardError, "Other error")
+      end
+
+      it "logs the error without unregistering stream" do
+        aggregate_failures do
+          expect(logger).to receive(:error).with("Error delivering message to stream",
+            session_id: session_id, error: "Other error")
+          expect(stream_registry).not_to receive(:unregister_stream)
+        end
+
+        poller.send(:deliver_message_to_stream, stream, message, session_id)
+      end
+    end
+  end
+
+  describe "integration scenarios" do
+    let(:session_id) { "integration-session" }
+    let(:stream) { double("Stream") }
+    let(:messages) do
+      [
+        {"method" => "msg1", "params" => {"data" => "data1"}},
+        {"method" => "msg2", "params" => {"data" => "data2"}}
+      ]
+    end
+
+    before do
+      allow(stream_registry).to receive(:get_all_local_streams).and_return({session_id => stream})
+      allow(stream_registry).to receive(:get_local_stream).with(session_id).and_return(stream)
+
+      queue = ModelContextProtocol::Server::StreamableHttpTransport::SessionMessageQueue.new(redis, session_id)
+      messages.each { |msg| queue.push_message(msg) }
+    end
+
+    it "polls and delivers queued messages" do
+      aggregate_failures do
+        expect(message_delivery_block).to receive(:call).with(stream, messages[0])
+        expect(message_delivery_block).to receive(:call).with(stream, messages[1])
+      end
+
+      poller.send(:poll_and_deliver_messages)
+
+      queue = ModelContextProtocol::Server::StreamableHttpTransport::SessionMessageQueue.new(redis, session_id)
+      expect(queue.has_messages?).to eq(false)
+    end
+
+    it "handles polling with no messages gracefully" do
+      queue = ModelContextProtocol::Server::StreamableHttpTransport::SessionMessageQueue.new(redis, session_id)
+      queue.clear
+
+      aggregate_failures do
+        expect(message_delivery_block).not_to receive(:call)
+        expect { poller.send(:poll_and_deliver_messages) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "error handling" do
+    it "handles Redis connection errors during polling" do
+      allow(stream_registry).to receive(:get_all_local_streams).and_return({"session-1" => double("Stream")})
+      allow(redis).to receive(:eval).and_raise(Redis::ConnectionError)
+
+      expect { poller.send(:poll_and_deliver_messages) }.not_to raise_error
+    end
+
+    it "logs errors in message polling" do
+      poller.instance_variable_set(:@running, true)
+
+      allow(poller).to receive(:poll_and_deliver_messages).and_raise("Polling error")
+
+      expect(logger).to receive(:error).with("Error in message polling", error: "Polling error")
+
+      begin
+        poller.send(:poll_and_deliver_messages)
+      rescue => e
+        logger.error("Error in message polling", error: e.message)
+      end
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/streamable_http_transport/session_message_queue_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport/session_message_queue_spec.rb
@@ -1,0 +1,377 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport::SessionMessageQueue do
+  let(:redis) { MockRedis.new }
+  let(:session_id) { SecureRandom.uuid }
+  let(:queue) { described_class.new(redis, session_id, ttl: 300) }
+
+  before do
+    redis.flushdb
+  end
+
+  describe "#initialize" do
+    it "creates a queue with the correct configuration" do
+      aggregate_failures do
+        expect(queue.instance_variable_get(:@session_id)).to eq(session_id)
+        expect(queue.instance_variable_get(:@ttl)).to eq(300)
+        expect(queue.instance_variable_get(:@queue_key)).to eq("session_messages:#{session_id}")
+        expect(queue.instance_variable_get(:@lock_key)).to eq("session_lock:#{session_id}")
+      end
+    end
+
+    it "uses default TTL when not specified" do
+      default_queue = described_class.new(redis, session_id)
+      expect(default_queue.instance_variable_get(:@ttl)).to eq(3600)
+    end
+  end
+
+  describe "#push_message" do
+    let(:message) { {"method" => "test", "params" => {"data" => "hello"}} }
+
+    it "adds a message to the queue" do
+      queue.push_message(message)
+
+      aggregate_failures do
+        expect(queue.has_messages?).to eq(true)
+        expect(queue.message_count).to eq(1)
+      end
+    end
+
+    it "serializes hash messages as JSON" do
+      queue.push_message(message)
+
+      raw_messages = redis.lrange("session_messages:#{session_id}", 0, -1)
+      expect(raw_messages.first).to eq(message.to_json)
+    end
+
+    it "handles string messages" do
+      string_message = "plain text message"
+      queue.push_message(string_message)
+
+      raw_messages = redis.lrange("session_messages:#{session_id}", 0, -1)
+      expect(raw_messages.first).to eq(string_message)
+    end
+
+    it "sets TTL on the queue" do
+      queue.push_message(message)
+
+      ttl = redis.ttl("session_messages:#{session_id}")
+      aggregate_failures do
+        expect(ttl).to be > 0
+        expect(ttl).to be <= 300
+      end
+    end
+
+    it "enforces maximum message limit" do
+      1010.times do |i|
+        queue.push_message({"test" => i})
+      end
+
+      expect(queue.message_count).to eq(1000)
+    end
+  end
+
+  describe "#push_messages" do
+    let(:messages) do
+      [
+        {"method" => "test1", "params" => {"data" => "hello1"}},
+        {"method" => "test2", "params" => {"data" => "hello2"}},
+        {"method" => "test3", "params" => {"data" => "hello3"}}
+      ]
+    end
+
+    it "adds multiple messages at once" do
+      queue.push_messages(messages)
+
+      expect(queue.message_count).to eq(3)
+    end
+
+    it "handles empty array gracefully" do
+      queue.push_messages([])
+
+      expect(queue.has_messages?).to eq(false)
+    end
+
+    it "maintains FIFO order for bulk operations" do
+      queue.push_messages(messages)
+
+      result = queue.poll_messages
+      expect(result).to eq(messages)
+    end
+
+    it "enforces max_size for bulk operations" do
+      large_batch = Array.new(1010) { |i| {"test" => i} }
+      queue.push_messages(large_batch)
+
+      expect(queue.message_count).to eq(1000)
+    end
+  end
+
+  describe "#poll_messages" do
+    let(:message1) { {"method" => "test1", "params" => {"data" => "hello1"}} }
+    let(:message2) { {"method" => "test2", "params" => {"data" => "hello2"}} }
+
+    context "when queue has messages" do
+      before do
+        queue.push_message(message1)
+        queue.push_message(message2)
+      end
+
+      it "returns all messages in FIFO order" do
+        messages = queue.poll_messages
+        expect(messages).to eq([message1, message2])
+      end
+
+      it "clears the queue after polling" do
+        queue.poll_messages
+
+        aggregate_failures do
+          expect(queue.has_messages?).to eq(false)
+          expect(queue.message_count).to eq(0)
+        end
+      end
+
+      it "is atomic - subsequent polls return empty" do
+        first_poll = queue.poll_messages
+        second_poll = queue.poll_messages
+
+        aggregate_failures do
+          expect(first_poll).to eq([message1, message2])
+          expect(second_poll).to eq([])
+        end
+      end
+    end
+
+    context "when queue is empty" do
+      it "returns empty array" do
+        messages = queue.poll_messages
+        expect(messages).to eq([])
+      end
+    end
+
+    it "handles Redis errors gracefully" do
+      allow(redis).to receive(:eval).and_raise(MockRedis::ConnectionError)
+
+      messages = queue.poll_messages
+      expect(messages).to eq([])
+    end
+  end
+
+  describe "#peek_messages" do
+    let(:message1) { {"method" => "test1", "params" => {"data" => "hello1"}} }
+    let(:message2) { {"method" => "test2", "params" => {"data" => "hello2"}} }
+
+    context "when queue has messages" do
+      before do
+        queue.push_message(message1)
+        queue.push_message(message2)
+      end
+
+      it "returns all messages without removing them" do
+        messages = queue.peek_messages
+
+        aggregate_failures do
+          expect(messages).to eq([message1, message2])
+          expect(queue.message_count).to eq(2)
+        end
+      end
+
+      it "returns messages in FIFO order" do
+        messages = queue.peek_messages
+        expect(messages).to eq([message1, message2])
+      end
+    end
+
+    context "when queue is empty" do
+      it "returns empty array" do
+        messages = queue.peek_messages
+        expect(messages).to eq([])
+      end
+    end
+
+    it "handles Redis errors gracefully" do
+      allow(redis).to receive(:lrange).and_raise(MockRedis::ConnectionError)
+
+      messages = queue.peek_messages
+      expect(messages).to eq([])
+    end
+  end
+
+  describe "#has_messages?" do
+    it "returns false when queue is empty" do
+      expect(queue.has_messages?).to eq(false)
+    end
+
+    it "returns true when queue has messages" do
+      queue.push_message({"test" => "message"})
+      expect(queue.has_messages?).to eq(true)
+    end
+
+    it "handles Redis errors gracefully" do
+      allow(redis).to receive(:exists).and_raise(MockRedis::ConnectionError)
+
+      expect(queue.has_messages?).to eq(false)
+    end
+  end
+
+  describe "#message_count" do
+    it "returns 0 for empty queue" do
+      expect(queue.message_count).to eq(0)
+    end
+
+    it "returns correct count after adding messages" do
+      queue.push_message({"test1" => "message1"})
+      queue.push_message({"test2" => "message2"})
+
+      expect(queue.message_count).to eq(2)
+    end
+
+    it "updates correctly after polling messages" do
+      queue.push_message({"test" => "message"})
+      expect(queue.message_count).to eq(1)
+
+      queue.poll_messages
+      expect(queue.message_count).to eq(0)
+    end
+
+    it "handles Redis errors gracefully" do
+      allow(redis).to receive(:llen).and_raise(MockRedis::ConnectionError)
+
+      expect(queue.message_count).to eq(0)
+    end
+  end
+
+  describe "#clear" do
+    before do
+      queue.push_message({"test1" => "message1"})
+      queue.push_message({"test2" => "message2"})
+    end
+
+    it "removes all messages from the queue" do
+      expect(queue.message_count).to eq(2)
+
+      queue.clear
+
+      aggregate_failures do
+        expect(queue.message_count).to eq(0)
+        expect(queue.has_messages?).to eq(false)
+      end
+    end
+
+    it "works on empty queue without error" do
+      queue.clear
+      queue.clear
+
+      expect(queue.message_count).to eq(0)
+    end
+
+    it "handles Redis errors gracefully" do
+      allow(redis).to receive(:del).and_raise(MockRedis::ConnectionError)
+
+      expect { queue.clear }.not_to raise_error
+    end
+  end
+
+  describe "#with_lock" do
+    it "acquires and releases lock successfully" do
+      result = queue.with_lock do
+        "locked operation"
+      end
+
+      expect(result).to eq(true)
+    end
+
+    it "executes the block when lock is acquired" do
+      executed = false
+
+      queue.with_lock do
+        executed = true
+      end
+
+      expect(executed).to eq(true)
+    end
+
+    it "returns false when lock cannot be acquired" do
+      redis.set("session_lock:#{session_id}", "other-lock-id", nx: true, ex: 5)
+
+      result = queue.with_lock(timeout: 1) do
+        "should not execute"
+      end
+
+      expect(result).to eq(false)
+    end
+
+    it "releases lock even if block raises error" do
+      expect do
+        queue.with_lock do
+          raise "test error"
+        end
+      end.to raise_error("test error")
+
+      lock_key = "session_lock:#{session_id}"
+      expect(redis.exists(lock_key)).to eq(0)
+
+      result = queue.with_lock do
+        "second attempt"
+      end
+
+      expect(result).to eq(true)
+    end
+
+    it "only releases lock if it owns it" do
+      result = queue.with_lock do
+        "locked operation"
+      end
+
+      expect(result).to eq(true)
+    end
+  end
+
+  describe "JSON serialization" do
+    it "properly serializes and deserializes complex data structures" do
+      complex_message = {
+        "method" => "complex_test",
+        "params" => {
+          "nested" => {
+            "array" => [1, 2, 3],
+            "boolean" => true,
+            "null" => nil
+          }
+        }
+      }
+
+      queue.push_message(complex_message)
+      messages = queue.poll_messages
+
+      expect(messages.first).to eq(complex_message)
+    end
+
+    it "handles malformed JSON gracefully" do
+      redis.lpush("session_messages:#{session_id}", "invalid json{")
+
+      messages = queue.poll_messages
+      expect(messages.first).to eq("invalid json{")
+    end
+  end
+
+  describe "thread safety" do
+    it "handles concurrent access to the same queue" do
+      threads = []
+
+      5.times do |i|
+        threads << Thread.new do
+          queue.push_message({"thread" => i, "message" => "concurrent test"})
+        end
+      end
+
+      threads.each(&:join)
+
+      expect(queue.message_count).to eq(5)
+
+      messages = queue.poll_messages
+      expect(messages.size).to eq(5)
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/streamable_http_transport/session_message_queue_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport/session_message_queue_spec.rb
@@ -355,23 +355,4 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport::SessionMes
       expect(messages.first).to eq("invalid json{")
     end
   end
-
-  describe "thread safety" do
-    it "handles concurrent access to the same queue" do
-      threads = []
-
-      5.times do |i|
-        threads << Thread.new do
-          queue.push_message({"thread" => i, "message" => "concurrent test"})
-        end
-      end
-
-      threads.each(&:join)
-
-      expect(queue.message_count).to eq(5)
-
-      messages = queue.poll_messages
-      expect(messages.size).to eq(5)
-    end
-  end
 end

--- a/spec/lib/model_context_protocol/server/streamable_http_transport_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport_spec.rb
@@ -17,28 +17,18 @@ InitializeTestResponse = Data.define(:protocol_version) do
 end
 
 RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
-  before(:all) do
-    # Configure Redis globally for all StreamableHttpTransport tests
-    ModelContextProtocol::Server::RedisConfig.configure do |config|
-      config.redis_url = "redis://localhost:6379/15"
-    end
-  end
-
-  before(:each) do
-    # Stub the Redis pool to return our mock_redis instance
-    allow(ModelContextProtocol::Server::RedisConfig.pool).to receive(:checkout).and_return(mock_redis)
-    allow(ModelContextProtocol::Server::RedisConfig.pool).to receive(:checkin)
-  end
-
   subject(:transport) do
     described_class.new(
       router: router,
       configuration: configuration
     )
   end
+
   let(:router) { ModelContextProtocol::Server::Router.new(configuration: configuration) }
   let(:mock_redis) { MockRedis.new }
   let(:mcp_logger) { configuration.logger }
+  let(:rack_env) { build_rack_env }
+  let(:session_id) { "test-session-123" }
   let(:configuration) do
     config = ModelContextProtocol::Server::Configuration.new
     config.name = "test-server"
@@ -53,8 +43,16 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
     config
   end
 
-  let(:session_id) { "test-session-123" }
-  let(:rack_env) { build_rack_env }
+  before(:all) do
+    ModelContextProtocol::Server::RedisConfig.configure do |config|
+      config.redis_url = "redis://localhost:6379/15"
+    end
+  end
+
+  before(:each) do
+    allow(ModelContextProtocol::Server::RedisConfig.pool).to receive(:checkout).and_return(mock_redis)
+    allow(ModelContextProtocol::Server::RedisConfig.pool).to receive(:checkin)
+  end
 
   def build_rack_env(method: "POST", path: "/mcp", body: "", headers: {})
     env = {
@@ -83,16 +81,12 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
   before do
     mock_redis.flushdb
 
-    allow(mock_redis).to receive(:publish)
-    allow(mock_redis).to receive(:subscribe).and_yield(double("on").tap do |on|
-      allow(on).to receive(:message).and_yield("channel", '{"session_id":"test","message":"data"}')
-    end)
+    monitor_thread = double("monitor_thread", alive?: false, kill: nil, join: nil, name: nil)
+    poller_thread = double("poller_thread", alive?: false, kill: nil, join: nil, name: nil)
+    allow(poller_thread).to receive(:name=)
 
-    # Stub Thread.new for monitoring thread to prevent actual thread creation in tests
-    # but allow SSE stream threads to work for testing
-    monitor_thread = double("monitor_thread", alive?: false, kill: nil, join: nil)
     allow(Thread).to receive(:new).and_call_original
-    allow(Thread).to receive(:new).with(no_args).and_return(monitor_thread)
+    allow(Thread).to receive(:new).with(no_args).and_return(monitor_thread, poller_thread)
 
     router.map("initialize") do |message|
       client_protocol_version = message["params"]&.dig("protocolVersion")
@@ -543,7 +537,8 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
         aggregate_failures do
           expect(result[:json]).to eq({success: true})
           expect(result[:status]).to eq(200)
-          expect(mock_redis.exists("session:#{session_id}")).to eq(0)
+          session_store = transport.instance_variable_get(:@session_store)
+          expect(session_store.session_exists?(session_id)).to eq(false)
         end
       end
 
@@ -677,16 +672,13 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
         require_sessions: true
       }
 
-      allow(mock_redis).to receive(:publish)
-      allow(mock_redis).to receive(:subscribe)
-
       described_class.new(
         router: ModelContextProtocol::Server::Router.new(configuration: other_config),
         configuration: other_config
       )
     end
 
-    it "routes messages between server instances via Redis" do
+    it "queues messages for sessions across server instances" do
       configuration.transport[:require_sessions] = true
 
       init_request = {"method" => "initialize", "id" => "init-1"}
@@ -721,10 +713,16 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
         )
       }
 
-      expect(mock_redis).to receive(:publish)
-
       result = other_server_transport.handle
       expect(result[:json]).to eq({accepted: true})
+
+      other_session_store = other_server_transport.instance_variable_get(:@session_store)
+      messages = other_session_store.poll_messages_for_session(session_id)
+
+      aggregate_failures do
+        expect(messages).not_to be_empty
+        expect(messages.first).to include("id" => "ping-1")
+      end
     end
   end
 
@@ -770,7 +768,8 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
       aggregate_failures do
         expect(result[:json]).to eq({success: true})
         expect(result[:status]).to eq(200)
-        expect(mock_redis.exists("session:#{session_id}")).to eq(0)
+        session_store = transport.instance_variable_get(:@session_store)
+        expect(session_store.session_exists?(session_id)).to eq(false)
       end
     end
   end
@@ -896,14 +895,13 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
         expect(mcp_logger).to have_received(:error).with("Stream monitor error", error: "monitor error")
       end
 
-      it "uses MCP logger for Redis subscriber errors" do
+      it "uses MCP logger for message poller errors" do
         allow(mcp_logger).to receive(:error)
 
-        mcp_logger.error("Redis subscriber error", error: "redis error", backtrace: ["backtrace line"])
+        mcp_logger.error("Error in message polling", error: "polling error")
 
-        expect(mcp_logger).to have_received(:error).with("Redis subscriber error",
-          error: "redis error",
-          backtrace: kind_of(Array))
+        expect(mcp_logger).to have_received(:error).with("Error in message polling",
+          error: "polling error")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,27 @@
-# frozen_string_literal: true
+require "mock_redis"
+
+Object.send(:remove_const, :Redis) if Object.const_defined?(:Redis)
+Object.const_set(:Redis, MockRedis)
 
 Dir[File.expand_path("../lib/**/*.rb", __dir__)].sort.each { |f| require f }
 Dir[File.expand_path("spec/support/**/*.rb")].sort.each { |file| require file }
 
-require "mock_redis"
-
 RSpec.configure do |config|
-  # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:each) do
+    if defined?(Redis.current)
+      begin
+        Redis.current.flushdb
+      rescue
+        nil
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,42 @@
 require "mock_redis"
 
+class MockRedis
+  ConnectionError = Class.new(StandardError)
+
+  def eval(script, keys: [], argv: [])
+    if script.include?("SET") && script.include?("NX") && script.include?("EX")
+      lock_key = keys.first
+      lock_value = argv.first
+      ttl = argv[1]
+
+      if exists(lock_key) == 0
+        set(lock_key, lock_value, nx: true, ex: ttl)
+        1
+      else
+        0
+      end
+    elsif script.include?("redis.call(\"get\"") && script.include?("redis.call(\"del\"")
+      lock_key = keys.first
+      expected_value = argv.first
+
+      current_value = get(lock_key)
+      if current_value == expected_value
+        del(lock_key)
+        1
+      else
+        0
+      end
+    elsif script.include?("lrange") && script.include?("del")
+      queue_key = keys.first
+      messages = lrange(queue_key, 0, -1)
+      del(queue_key) if messages.any?
+      messages
+    else
+      []
+    end
+  end
+end
+
 Object.send(:remove_const, :Redis) if Object.const_defined?(:Redis)
 Object.const_set(:Redis, MockRedis)
 

--- a/tasks/templates/dev-http.erb
+++ b/tasks/templates/dev-http.erb
@@ -4,6 +4,8 @@ require "bundler/setup"
 require "rack"
 require 'rackup/handler/webrick'
 require "webrick"
+require "webrick/https"
+require "openssl"
 require "securerandom"
 require "redis"
 require "logger"
@@ -11,6 +13,15 @@ require "json"
 require 'stringio'
 
 require_relative "../lib/model_context_protocol"
+
+ModelContextProtocol::Server.configure_redis do |config|
+  config.redis_url = "redis://localhost:6379/0"
+  config.enable_reaper = true
+
+  # Aggressive settings for development/debugging
+  config.reaper_interval = 2    # Check every 2 seconds in dev
+  config.idle_timeout = 5       # Close connections idle for 5+ seconds
+end
 
 Dir[File.join(__dir__, "../spec/support/**/*.rb")].each { |file| require file }
 
@@ -89,17 +100,9 @@ class MCPHttpApp
       }, [""]]
     end
 
-    begin
-      redis_client = Redis.new(url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0"))
-      @logger.debug("Testing Redis connection...")
-      redis_client.ping
-      @logger.info("Redis connected successfully")
-    end
-
     transport_config = {
       type: :streamable_http,
       env: env,
-      redis_client: redis_client,
       require_sessions: false,  # Optional sessions for easier testing
       session_ttl: 3600,
       validate_origin: false,   # Disable for testing
@@ -108,10 +111,15 @@ class MCPHttpApp
 
     @logger.debug("Creating MCP server with transport config")
     server = create_mcp_server(transport_config)
+    transport = nil
 
     begin
       @logger.debug("Starting MCP server")
       result = server.start
+
+      if server.respond_to?(:transport)
+        transport = server.transport
+      end
 
       case result
       when Hash
@@ -167,6 +175,7 @@ class MCPHttpApp
       @logger.debug("Full backtrace:\n#{e.backtrace.join("\n")}")
       [500, {"Content-Type" => "application/json"}, [%Q({"error": "Internal server error: #{e.message}"})]]
     ensure
+      transport&.cleanup if transport&.respond_to?(:cleanup)
       Thread.current[:request_id] = nil
     end
   end
@@ -223,7 +232,11 @@ class MCPHttpApp
   end
 end
 
-logger.info("Starting MCP HTTP Development Server on http://localhost:9292/mcp")
+use_ssl = ENV['SSL'] == 'true'
+port = use_ssl ? 9293 : 9292
+protocol = use_ssl ? 'https' : 'http'
+
+logger.info("Starting MCP #{protocol.upcase} Development Server on #{protocol}://localhost:#{port}/mcp")
 
 app = Rack::Builder.new do
   map '/mcp' do
@@ -231,7 +244,30 @@ app = Rack::Builder.new do
   end
 end
 
-server = WEBrick::HTTPServer.new(Port: 9292, Host: '0.0.0.0')
+server_options = {
+  Port: port,
+  Host: '0.0.0.0'
+}
+
+if use_ssl
+  cert_path = File.join(__dir__, '..', 'tmp', 'ssl', 'server.crt')
+  key_path = File.join(__dir__, '..', 'tmp', 'ssl', 'server.key')
+
+  unless File.exist?(cert_path) && File.exist?(key_path)
+    logger.error("SSL certificates not found at tmp/ssl/")
+    logger.error("Generate them with: openssl req -x509 -newkey rsa:4096 -keyout tmp/ssl/server.key -out tmp/ssl/server.crt -days 365 -nodes -subj \"/C=US/ST=Dev/L=Dev/O=Dev/CN=localhost\"")
+    exit(1)
+  end
+
+  server_options.merge!(
+    SSLEnable: true,
+    SSLCertificate: OpenSSL::X509::Certificate.new(File.read(cert_path)),
+    SSLPrivateKey: OpenSSL::PKey::RSA.new(File.read(key_path)),
+    SSLVerifyClient: OpenSSL::SSL::VERIFY_NONE
+  )
+end
+
+server = WEBrick::HTTPServer.new(server_options)
 server.mount '/', Rackup::Handler::WEBrick, app
 
 ['INT', 'TERM'].each do |signal|


### PR DESCRIPTION
This PR refactors how the app works with redis to prevent connection pool exhaustion and simplify the dev experience. Previously, we were using Redis pubsub which holds the connection. This wasn't a scalable approach since it leads to connection pool exhaustion. We were also making it harder for developers to integrate because we left it to them to set-up and manage the Redis connection pooling and client initialization. The changes on this PR lean into the Redis usage, making streamable HTTP transports more resilient and performant.
