### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [Unreleased]
 
+## [0.5.0] - 2025-09-22
+
 - Make streamable HTTP transport thread-safe by using Redis to manage state.
+- Implement Redis connection pooling with robust management and configuration.
+- Automatically upgrade connection to SSE to send notifications.
+- Add support for cancellations and progress notifications via `cancellable` and `progressable` blocks in prompts, resources, and tools.
 
 ## [0.4.0] - 2025-09-07
 
@@ -69,7 +74,8 @@
 
 - Initial release
 
-[Unreleased]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.3.2...v0.3.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    model-context-protocol-rb (0.4.0)
+    model-context-protocol-rb (0.5.0)
       addressable (~> 2.8)
       concurrent-ruby (~> 1.3)
       connection_pool (~> 2.4)

--- a/lib/model_context_protocol/version.rb
+++ b/lib/model_context_protocol/version.rb
@@ -1,3 +1,3 @@
 module ModelContextProtocol
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
This PR preps the v0.5.0 release. See CHANGELOG for notes on changes.
