### PR TITLE
Prepare v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.5.1] - 2025-09-23
+
+- (Fix) Ensure streams are properly closed when clients disconnect.
+
 ## [0.5.0] - 2025-09-22
 
 - Make streamable HTTP transport thread-safe by using Redis to manage state.
@@ -75,6 +79,7 @@
 - Initial release
 
 [Unreleased]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.5.0...HEAD
+[0.5.1]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/dickdavis/model-context-protocol-rb/compare/v0.3.3...v0.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    model-context-protocol-rb (0.5.0)
+    model-context-protocol-rb (0.5.1)
       addressable (~> 2.8)
       concurrent-ruby (~> 1.3)
       connection_pool (~> 2.4)

--- a/lib/model_context_protocol/version.rb
+++ b/lib/model_context_protocol/version.rb
@@ -1,3 +1,3 @@
 module ModelContextProtocol
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
This PR prepares the release of v0.5.1; see the CHANGELOG for details.
