### PR TITLE
Always enable MCP spec logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ class ModelContextProtocolController < ActionController::API
       config.name = "MyMCPServer"
       config.title = "My MCP Server"
       config.version = "1.0.0"
-      config.logging_enabled = true
       config.registry = build_registry
       config.context = {
         user_id: current_user.id,
@@ -210,9 +209,6 @@ server = ModelContextProtocol::Server.new do |config|
     Use this server when you need to interact with the local development environment.
   INSTRUCTIONS
 
-  # Enable or disable MCP server logging
-  config.logging_enabled = true
-
   # Configure pagination options for the following methods:
   # prompts/list, resources/list, resource_template/list, tools/list
   config.pagination = {
@@ -281,7 +277,6 @@ The following table details all available configuration options for the MCP serv
 | `version` | String | Yes | - | Version of the MCP server |
 | `title` | String | No | - | Human-readable display name for the MCP server |
 | `instructions` | String | No | - | Instructions for how the MCP server should be used by LLMs |
-| `logging_enabled` | Boolean | No | `true` | Enable or disable MCP server logging |
 | `pagination` | Hash/Boolean | No | See pagination table | Pagination configuration (or `false` to disable) |
 | `context` | Hash | No | `{}` | Contextual variables available to prompts, resources, and tools |
 | `transport` | Hash | No | `{ type: :stdio }` | Transport configuration |

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -257,7 +257,7 @@ module ModelContextProtocol
     def build_capabilities
       {}.tap do |capabilities|
         capabilities[:completions] = {}
-        capabilities[:logging] = {} if configuration.logging_enabled?
+        capabilities[:logging] = {}
 
         registry = configuration.registry
 

--- a/lib/model_context_protocol/server/configuration.rb
+++ b/lib/model_context_protocol/server/configuration.rb
@@ -36,25 +36,10 @@ module ModelContextProtocol
     attr_reader :logger
 
     def initialize
-      @logging_enabled = true
       @default_log_level = "info"
       @logger = ModelContextProtocol::Server::MCPLogger.new(
         logger_name: "server",
-        level: @default_log_level,
-        enabled: @logging_enabled
-      )
-    end
-
-    def logging_enabled?
-      @logging_enabled
-    end
-
-    def logging_enabled=(value)
-      @logging_enabled = value
-      @logger = ModelContextProtocol::Server::MCPLogger.new(
-        logger_name: "server",
-        level: @default_log_level,
-        enabled: value
+        level: @default_log_level
       )
     end
 

--- a/lib/model_context_protocol/server/stdio_transport.rb
+++ b/lib/model_context_protocol/server/stdio_transport.rb
@@ -72,7 +72,7 @@ module ModelContextProtocol
       $stdout.puts(JSON.generate(notification))
       $stdout.flush
     rescue IOError => e
-      @configuration.logger.debug("Failed to send notification", error: e.message) if @configuration.logging_enabled?
+      @configuration.logger.debug("Failed to send notification", error: e.message)
     end
 
     private

--- a/spec/lib/model_context_protocol/server/configuration_spec.rb
+++ b/spec/lib/model_context_protocol/server/configuration_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe ModelContextProtocol::Server::Configuration do
         config.name = "test-server"
         config.registry = registry
         config.version = "1.0.0"
-        config.logging_enabled = true
       end
 
       config = server.configuration
@@ -19,27 +18,6 @@ RSpec.describe ModelContextProtocol::Server::Configuration do
         expect(config.name).to eq("test-server")
         expect(config.registry).to eq(registry)
         expect(config.version).to eq("1.0.0")
-        expect(config.logging_enabled?).to be true
-      end
-    end
-  end
-
-  describe "#logging_enabled?" do
-    it "returns true by default" do
-      expect(configuration.logging_enabled?).to be(true)
-    end
-
-    context "when logging_enabled is explicitly set to true" do
-      it "returns true" do
-        configuration.logging_enabled = true
-        expect(configuration.logging_enabled?).to be(true)
-      end
-    end
-
-    context "when logging_enabled is set to false" do
-      it "returns false" do
-        configuration.logging_enabled = false
-        expect(configuration.logging_enabled?).to be(false)
       end
     end
   end
@@ -49,42 +27,12 @@ RSpec.describe ModelContextProtocol::Server::Configuration do
       expect(configuration.logger).to be_a(ModelContextProtocol::Server::MCPLogger)
     end
 
-    it "creates an enabled logger by default" do
-      expect(configuration.logger.enabled).to be(true)
-    end
-
-    it "creates a disabled logger when logging is disabled" do
-      configuration.logging_enabled = false
-      expect(configuration.logger.enabled).to be(false)
-    end
-
     it "sets default logger name to 'server'" do
       expect(configuration.logger.logger_name).to eq("server")
     end
 
     it "sets default log level to INFO" do
       expect(configuration.logger.level).to eq(Logger::INFO)
-    end
-  end
-
-  describe "#logging_enabled=" do
-    it "recreates the logger with new enabled state" do
-      original_logger = configuration.logger
-
-      configuration.logging_enabled = false
-
-      aggregate_failures do
-        expect(configuration.logger).not_to eq(original_logger)
-        expect(configuration.logger.enabled).to be(false)
-      end
-    end
-
-    it "preserves log level when recreating logger" do
-      configuration.default_log_level = "debug"
-
-      configuration.logging_enabled = false
-
-      expect(configuration.logger.level).to eq(Logger::DEBUG)
     end
   end
 

--- a/spec/lib/model_context_protocol/server/mcp_logger_spec.rb
+++ b/spec/lib/model_context_protocol/server/mcp_logger_spec.rb
@@ -10,17 +10,15 @@ RSpec.describe ModelContextProtocol::Server::MCPLogger do
 
       aggregate_failures do
         expect(logger.logger_name).to eq("server")
-        expect(logger.enabled).to be(true)
         expect(logger.level).to eq(Logger::INFO)
       end
     end
 
     it "accepts custom settings" do
-      logger = described_class.new(logger_name: "custom", level: "debug", enabled: false)
+      logger = described_class.new(logger_name: "custom", level: "debug")
 
       aggregate_failures do
         expect(logger.logger_name).to eq("custom")
-        expect(logger.enabled).to be(false)
         expect(logger.level).to eq(Logger::DEBUG)
       end
     end
@@ -32,7 +30,7 @@ RSpec.describe ModelContextProtocol::Server::MCPLogger do
       logger.connect_transport(transport)
     end
 
-    describe "when enabled" do
+    describe "logging behavior" do
       it "sends debug messages when level is debug" do
         logger.level = Logger::DEBUG
         logger.debug("test message", key: "value")
@@ -138,15 +136,6 @@ RSpec.describe ModelContextProtocol::Server::MCPLogger do
         )
       end
     end
-
-    describe "when disabled" do
-      let(:logger) { described_class.new(enabled: false) }
-
-      it "does not send notifications" do
-        logger.info("test message")
-        expect(transport).not_to have_received(:send_notification)
-      end
-    end
   end
 
   describe "log level filtering" do
@@ -235,16 +224,6 @@ RSpec.describe ModelContextProtocol::Server::MCPLogger do
             }
           )
         end
-      end
-
-      it "does not flush when disabled" do
-        disabled_logger = described_class.new(enabled: false)
-        disabled_logger.info("disabled message")
-
-        allow(transport).to receive(:send_notification)
-        disabled_logger.connect_transport(transport)
-
-        expect(transport).not_to have_received(:send_notification)
       end
     end
   end

--- a/spec/lib/model_context_protocol/server/stdio_transport_spec.rb
+++ b/spec/lib/model_context_protocol/server/stdio_transport_spec.rb
@@ -264,20 +264,6 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
           transport.send_notification("notifications/message", {level: "error", data: {}})
         }.not_to raise_error
       end
-
-      context "when logging is disabled" do
-        before do
-          configuration.logging_enabled = false
-        end
-
-        it "does not log debug messages about failed notifications when logging disabled" do
-          allow($stdout).to receive(:puts).and_raise(IOError, "broken pipe")
-          allow($stdout).to receive(:flush)
-          expect(mcp_logger).not_to receive(:debug)
-
-          transport.send_notification("notifications/message", {level: "info", data: {}})
-        end
-      end
     end
   end
 

--- a/spec/lib/model_context_protocol/server/streamable_http_transport_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport_spec.rb
@@ -1123,22 +1123,6 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
           }.not_to raise_error
         end
       end
-
-      context "when logging is disabled" do
-        before do
-          configuration.logging_enabled = false
-          transport.instance_variable_set(:@configuration, configuration)
-        end
-
-        it "does not attempt to log" do
-          request_store = transport.instance_variable_get(:@request_store)
-          request_store.register_request(request_id, session_id)
-
-          transport.send(:handle_cancellation, cancellation_message, session_id)
-
-          expect(mcp_logger).not_to have_received(:debug)
-        end
-      end
     end
 
     describe "integration with request processing" do

--- a/spec/lib/model_context_protocol/server_spec.rb
+++ b/spec/lib/model_context_protocol/server_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe ModelContextProtocol::Server do
       server = ModelContextProtocol::Server.new do |config|
         config.name = "MCP Development Server"
         config.version = "1.0.0"
-        config.logging_enabled = true
         config.registry = ModelContextProtocol::Server::Registry.new
         config.transport = :unknown_transport
       end
@@ -39,7 +38,6 @@ RSpec.describe ModelContextProtocol::Server do
       server = ModelContextProtocol::Server.new do |config|
         config.name = "MCP Development Server"
         config.version = "1.0.0"
-        config.logging_enabled = true
         config.registry = ModelContextProtocol::Server::Registry.new
       end
       server.start
@@ -59,7 +57,6 @@ RSpec.describe ModelContextProtocol::Server do
       server = ModelContextProtocol::Server.new do |config|
         config.name = "MCP Development Server"
         config.version = "1.0.0"
-        config.logging_enabled = true
         config.registry = ModelContextProtocol::Server::Registry.new
         config.transport = {
           type: :streamable_http


### PR DESCRIPTION
This PR removes the configuration option for enabling MCP client logging. This adds unnecessary complexity without a justifiable reason.
