### PR TITLE
Update existing logger references to client_logger in preparation of server logging capability

### DIFF
--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -158,7 +158,7 @@ module ModelContextProtocol
           raise ModelContextProtocol::Server::ParameterValidationError, "resource not found for #{uri}"
         end
 
-        resource.call
+        resource.call(configuration.client_logger, configuration.context)
       end
 
       router.map("resources/templates/list") do |message|

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -1,5 +1,3 @@
-require "logger"
-
 module ModelContextProtocol
   class Server
     # Raised when invalid response arguments are provided.
@@ -98,11 +96,11 @@ module ModelContextProtocol
       router.map("logging/setLevel") do |message|
         level = message["params"]["level"]
 
-        unless Configuration::VALID_LOG_LEVELS.include?(level)
-          raise ParameterValidationError, "Invalid log level: #{level}. Valid levels are: #{Configuration::VALID_LOG_LEVELS.join(", ")}"
+        unless ClientLogger::VALID_LOG_LEVELS.include?(level)
+          raise ParameterValidationError, "Invalid log level: #{level}. Valid levels are: #{ClientLogger::VALID_LOG_LEVELS.join(", ")}"
         end
 
-        configuration.logger.set_mcp_level(level)
+        configuration.client_logger.set_mcp_level(level)
         LoggingSetLevelResponse[]
       end
 
@@ -217,7 +215,7 @@ module ModelContextProtocol
         configuration
           .registry
           .find_prompt(message["params"]["name"])
-          .call(symbolized_arguments, configuration.logger, configuration.context)
+          .call(symbolized_arguments, configuration.client_logger, configuration.context)
       end
 
       router.map("tools/list") do |message|
@@ -250,7 +248,7 @@ module ModelContextProtocol
         configuration
           .registry
           .find_tool(message["params"]["name"])
-          .call(symbolized_arguments, configuration.logger, configuration.context)
+          .call(symbolized_arguments, configuration.client_logger, configuration.context)
       end
     end
 

--- a/lib/model_context_protocol/server/client_logger.rb
+++ b/lib/model_context_protocol/server/client_logger.rb
@@ -3,10 +3,12 @@ require "forwardable"
 require "json"
 
 module ModelContextProtocol
-  class Server::MCPLogger
+  class Server::ClientLogger
     extend Forwardable
 
     def_delegators :@internal_logger, :datetime_format=, :formatter=, :progname, :progname=
+
+    VALID_LOG_LEVELS = %w[debug info notice warning error critical alert emergency].freeze
 
     LEVEL_MAP = {
       "debug" => Logger::DEBUG,

--- a/lib/model_context_protocol/server/configuration.rb
+++ b/lib/model_context_protocol/server/configuration.rb
@@ -1,5 +1,3 @@
-require_relative "mcp_logger"
-
 module ModelContextProtocol
   class Server::Configuration
     # Raised when configured with invalid name.
@@ -23,33 +21,17 @@ module ModelContextProtocol
     # Raised when transport configuration is invalid
     class InvalidTransportError < StandardError; end
 
-    # Raised when an invalid log level is provided
-    class InvalidLogLevelError < StandardError; end
-
     # Raised when pagination configuration is invalid
     class InvalidPaginationError < StandardError; end
 
-    # Valid MCP log levels per the specification
-    VALID_LOG_LEVELS = %w[debug info notice warning error critical alert emergency].freeze
-
     attr_accessor :name, :registry, :version, :transport, :pagination, :title, :instructions
-    attr_reader :logger
+    attr_reader :client_logger
 
     def initialize
-      @default_log_level = "info"
-      @logger = ModelContextProtocol::Server::MCPLogger.new(
+      @client_logger = ModelContextProtocol::Server::ClientLogger.new(
         logger_name: "server",
-        level: @default_log_level
+        level: "info"
       )
-    end
-
-    def default_log_level=(level)
-      unless VALID_LOG_LEVELS.include?(level.to_s)
-        raise InvalidLogLevelError, "Invalid log level: #{level}. Valid levels are: #{VALID_LOG_LEVELS.join(", ")}"
-      end
-
-      @default_log_level = level.to_s
-      @logger.set_mcp_level(@default_log_level)
     end
 
     def transport_type

--- a/lib/model_context_protocol/server/prompt.rb
+++ b/lib/model_context_protocol/server/prompt.rb
@@ -4,13 +4,13 @@ module ModelContextProtocol
     include ModelContextProtocol::Server::ContentHelpers
     include ModelContextProtocol::Server::Progressable
 
-    attr_reader :arguments, :context, :logger
+    attr_reader :arguments, :context, :client_logger
 
-    def initialize(arguments, logger, context = {})
+    def initialize(arguments, client_logger, context = {})
       validate!(arguments)
       @arguments = arguments
       @context = context
-      @logger = logger
+      @client_logger = client_logger
     end
 
     def call
@@ -90,8 +90,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@defined_arguments, @defined_arguments&.dup)
       end
 
-      def call(arguments, logger, context = {})
-        new(arguments, logger, context).call
+      def call(arguments, client_logger, context = {})
+        new(arguments, client_logger, context).call
       rescue ArgumentError => error
         raise ModelContextProtocol::Server::ParameterValidationError, error.message
       end
@@ -127,8 +127,8 @@ module ModelContextProtocol
         @prompt_instance.context
       end
 
-      def logger
-        @prompt_instance.logger
+      def client_logger
+        @prompt_instance.client_logger
       end
 
       def user_message(&block)

--- a/lib/model_context_protocol/server/resource.rb
+++ b/lib/model_context_protocol/server/resource.rb
@@ -3,11 +3,13 @@ module ModelContextProtocol
     include ModelContextProtocol::Server::Cancellable
     include ModelContextProtocol::Server::Progressable
 
-    attr_reader :mime_type, :uri
+    attr_reader :mime_type, :uri, :client_logger, :context
 
-    def initialize
+    def initialize(client_logger, context = {})
       @mime_type = self.class.mime_type
       @uri = self.class.uri
+      @client_logger = client_logger
+      @context = context
     end
 
     def call
@@ -71,8 +73,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@annotations, @annotations&.dup)
       end
 
-      def call
-        new.call
+      def call(client_logger, context = {})
+        new(client_logger, context).call
       end
 
       def definition

--- a/lib/model_context_protocol/server/streamable_http_transport/message_poller.rb
+++ b/lib/model_context_protocol/server/streamable_http_transport/message_poller.rb
@@ -6,10 +6,10 @@ module ModelContextProtocol
       POLL_INTERVAL = 0.1  # 100ms
       BATCH_SIZE = 100
 
-      def initialize(redis_client, stream_registry, logger, &message_delivery_block)
+      def initialize(redis_client, stream_registry, client_logger, &message_delivery_block)
         @redis = redis_client
         @stream_registry = stream_registry
-        @logger = logger
+        @client_logger = client_logger
         @message_delivery_block = message_delivery_block
         @running = false
         @poll_thread = nil
@@ -22,14 +22,14 @@ module ModelContextProtocol
         @poll_thread = Thread.new do
           poll_loop
         rescue => e
-          @logger.error("Message poller thread error", error: e.message, backtrace: e.backtrace.first(5))
+          @client_logger.error("Message poller thread error", error: e.message, backtrace: e.backtrace.first(5))
           sleep 1
           retry if @running
         end
 
         @poll_thread.name = "MCP-MessagePoller" if @poll_thread.respond_to?(:name=)
 
-        @logger.debug("Message poller started")
+        @client_logger.debug("Message poller started")
       end
 
       def stop
@@ -41,7 +41,7 @@ module ModelContextProtocol
         end
 
         @poll_thread = nil
-        @logger.debug("Message poller stopped")
+        @client_logger.debug("Message poller stopped")
       end
 
       def running?
@@ -55,7 +55,7 @@ module ModelContextProtocol
           begin
             poll_and_deliver_messages
           rescue => e
-            @logger.error("Error in message polling", error: e.message)
+            @client_logger.error("Error in message polling", error: e.message)
           end
 
           sleep POLL_INTERVAL
@@ -91,9 +91,9 @@ module ModelContextProtocol
         @message_delivery_block&.call(stream, message)
       rescue IOError, Errno::EPIPE, Errno::ECONNRESET
         @stream_registry.unregister_stream(session_id)
-        @logger.debug("Unregistered disconnected stream", session_id: session_id)
+        @client_logger.debug("Unregistered disconnected stream", session_id: session_id)
       rescue => e
-        @logger.error("Error delivering message to stream",
+        @client_logger.error("Error delivering message to stream",
           session_id: session_id, error: e.message)
       end
     end

--- a/lib/model_context_protocol/server/tool.rb
+++ b/lib/model_context_protocol/server/tool.rb
@@ -9,13 +9,13 @@ module ModelContextProtocol
     include ModelContextProtocol::Server::ContentHelpers
     include ModelContextProtocol::Server::Progressable
 
-    attr_reader :arguments, :context, :logger
+    attr_reader :arguments, :context, :client_logger
 
-    def initialize(arguments, logger, context = {})
+    def initialize(arguments, client_logger, context = {})
       validate!(arguments)
       @arguments = arguments
       @context = context
-      @logger = logger
+      @client_logger = client_logger
     end
 
     def call
@@ -103,8 +103,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@output_schema, @output_schema)
       end
 
-      def call(arguments, logger, context = {})
-        new(arguments, logger, context).call
+      def call(arguments, client_logger, context = {})
+        new(arguments, client_logger, context).call
       rescue JSON::Schema::ValidationError => validation_error
         raise ModelContextProtocol::Server::ParameterValidationError, validation_error.message
       rescue OutputSchemaValidationError, ModelContextProtocol::Server::ResponseArgumentsError => tool_error

--- a/spec/lib/model_context_protocol/server/client_logger_spec.rb
+++ b/spec/lib/model_context_protocol/server/client_logger_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe ModelContextProtocol::Server::MCPLogger do
+RSpec.describe ModelContextProtocol::Server::ClientLogger do
   let(:transport) { double("transport") }
   let(:logger) { described_class.new(logger_name: "test-logger") }
 

--- a/spec/lib/model_context_protocol/server/configuration_spec.rb
+++ b/spec/lib/model_context_protocol/server/configuration_spec.rb
@@ -22,62 +22,17 @@ RSpec.describe ModelContextProtocol::Server::Configuration do
     end
   end
 
-  describe "#logger" do
+  describe "#client_logger" do
     it "always provides a logger instance" do
-      expect(configuration.logger).to be_a(ModelContextProtocol::Server::MCPLogger)
+      expect(configuration.client_logger).to be_a(ModelContextProtocol::Server::ClientLogger)
     end
 
     it "sets default logger name to 'server'" do
-      expect(configuration.logger.logger_name).to eq("server")
+      expect(configuration.client_logger.logger_name).to eq("server")
     end
 
     it "sets default log level to INFO" do
-      expect(configuration.logger.level).to eq(Logger::INFO)
-    end
-  end
-
-  describe "#default_log_level=" do
-    it "updates the logger's level" do
-      configuration.default_log_level = "debug"
-
-      expect(configuration.logger.level).to eq(Logger::DEBUG)
-    end
-
-    it "handles all MCP log levels" do
-      {
-        "debug" => Logger::DEBUG,
-        "info" => Logger::INFO,
-        "notice" => Logger::INFO,
-        "warning" => Logger::WARN,
-        "error" => Logger::ERROR,
-        "critical" => Logger::FATAL,
-        "alert" => Logger::FATAL,
-        "emergency" => Logger::UNKNOWN
-      }.each do |mcp_level, logger_level|
-        configuration.default_log_level = mcp_level
-        expect(configuration.logger.level).to eq(logger_level)
-      end
-    end
-
-    it "raises error for invalid log levels" do
-      expect {
-        configuration.default_log_level = "invalid"
-      }.to raise_error(
-        ModelContextProtocol::Server::Configuration::InvalidLogLevelError,
-        "Invalid log level: invalid. Valid levels are: debug, info, notice, warning, error, critical, alert, emergency"
-      )
-    end
-
-    it "accepts symbol log levels" do
-      configuration.default_log_level = :debug
-
-      expect(configuration.logger.level).to eq(Logger::DEBUG)
-    end
-
-    it "accepts string log levels" do
-      configuration.default_log_level = "warning"
-
-      expect(configuration.logger.level).to eq(Logger::WARN)
+      expect(configuration.client_logger.level).to eq(Logger::INFO)
     end
   end
 

--- a/spec/lib/model_context_protocol/server/content_helpers_spec.rb
+++ b/spec/lib/model_context_protocol/server/content_helpers_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe ModelContextProtocol::Server::ContentHelpers do
   end
 
   let(:helper) { test_class.new }
+  let(:client_logger) { double("client_logger") }
+
+  before do
+    allow(client_logger).to receive(:info)
+  end
 
   describe "#text_content" do
     context "with valid data" do
@@ -188,7 +193,7 @@ RSpec.describe ModelContextProtocol::Server::ContentHelpers do
   describe "#embedded_resource_content" do
     context "with valid data" do
       it "returns an EmbeddedResource content object" do
-        resource_data = TestResource.call
+        resource_data = TestResource.call(client_logger)
         result = helper.embedded_resource_content(resource: resource_data)
 
         aggregate_failures do
@@ -198,7 +203,7 @@ RSpec.describe ModelContextProtocol::Server::ContentHelpers do
       end
 
       it "returns an EmbeddedResource content object with annotations" do
-        resource_data = TestResource.call
+        resource_data = TestResource.call(client_logger)
         result = helper.embedded_resource_content(resource: resource_data)
 
         aggregate_failures do

--- a/spec/lib/model_context_protocol/server/prompt_spec.rb
+++ b/spec/lib/model_context_protocol/server/prompt_spec.rb
@@ -1,15 +1,16 @@
 require "spec_helper"
 
 RSpec.describe ModelContextProtocol::Server::Prompt do
+  let(:client_logger) { double("client_logger") }
+
   describe ".call" do
     context "when argument validation fails" do
       let(:invalid_arguments) { {foo: "bar"} }
 
       it "raises a ParameterValidationError" do
         expect {
-          logger = double("logger")
-          allow(logger).to receive(:info)
-          TestPrompt.call(invalid_arguments, logger)
+          allow(client_logger).to receive(:info)
+          TestPrompt.call(invalid_arguments, client_logger)
         }.to raise_error(ModelContextProtocol::Server::ParameterValidationError)
       end
     end
@@ -18,17 +19,15 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
       let(:valid_arguments) { {undesirable_activity: "clean the garage"} }
 
       it "instantiates the prompt with the provided arguments" do
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        allow(logger).to receive(:info)
-        expect(TestPrompt).to receive(:new).with(valid_arguments, logger, {}).and_call_original
-        TestPrompt.call(valid_arguments, logger)
+        allow(client_logger).to receive(:info)
+        allow(client_logger).to receive(:info)
+        expect(TestPrompt).to receive(:new).with(valid_arguments, client_logger, {}).and_call_original
+        TestPrompt.call(valid_arguments, client_logger)
       end
 
       it "returns the response from the instance's call method" do
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        response = TestPrompt.call(valid_arguments, logger)
+        allow(client_logger).to receive(:info)
+        response = TestPrompt.call(valid_arguments, client_logger)
         aggregate_failures do
           expect(response.messages.first[:content][:text]).to eq("My wife wants me to: clean the garage... Can you believe it?")
           expect(response.serialized[:description]).to eq("A prompt for brainstorming excuses to get out of something")
@@ -45,23 +44,20 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
     let(:context) { {"user_id" => "456", "environment" => "test"} }
 
     it "passes context to the instance" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      expect(TestPrompt).to receive(:new).with(valid_arguments, logger, context).and_call_original
-      TestPrompt.call(valid_arguments, logger, context)
+      allow(client_logger).to receive(:info)
+      expect(TestPrompt).to receive(:new).with(valid_arguments, client_logger, context).and_call_original
+      TestPrompt.call(valid_arguments, client_logger, context)
     end
 
     it "works with empty context" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      response = TestPrompt.call(valid_arguments, logger, {})
+      allow(client_logger).to receive(:info)
+      response = TestPrompt.call(valid_arguments, client_logger, {})
       expect(response.messages.first[:content][:text]).to eq("My wife wants me to: clean the garage... Can you believe it?")
     end
 
     it "works when context is not provided" do
-      logger = double("logger")
-      allow(logger).to receive(:info)
-      response = TestPrompt.call(valid_arguments, logger)
+      allow(client_logger).to receive(:info)
+      response = TestPrompt.call(valid_arguments, client_logger)
       expect(response.messages.first[:content][:text]).to eq("My wife wants me to: clean the garage... Can you believe it?")
     end
   end
@@ -75,40 +71,35 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
 
     context "when invalid arguments are provided" do
       it "raises an ArgumentError" do
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        expect { TestPrompt.new({foo: "bar"}, logger) }.to raise_error(ArgumentError)
+        allow(client_logger).to receive(:info)
+        expect { TestPrompt.new({foo: "bar"}, client_logger) }.to raise_error(ArgumentError)
       end
     end
 
     context "when valid arguments are provided" do
       it "stores the arguments" do
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, logger)
+        allow(client_logger).to receive(:info)
+        prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, client_logger)
         expect(prompt.arguments).to eq({undesirable_activity: "clean the garage"})
       end
 
       it "stores context when provided" do
         context = {"user_id" => "123", "session" => "abc"}
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, logger, context)
+        allow(client_logger).to receive(:info)
+        prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, client_logger, context)
         expect(prompt.context).to eq(context)
       end
 
       it "defaults to empty hash when no context provided" do
-        logger = double("logger")
-        allow(logger).to receive(:info)
-        prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, logger)
+        allow(client_logger).to receive(:info)
+        prompt = TestPrompt.new({undesirable_activity: "clean the garage"}, client_logger)
         expect(prompt.context).to eq({})
       end
 
       context "when optional arguments are provided" do
         it "stores the arguments" do
-          logger = double("logger")
-          allow(logger).to receive(:info)
-          prompt = TestPrompt.new({undesirable_activity: "clean the garage", tone: "whiny"}, logger)
+          allow(client_logger).to receive(:info)
+          prompt = TestPrompt.new({undesirable_activity: "clean the garage", tone: "whiny"}, client_logger)
           expect(prompt.arguments).to eq({undesirable_activity: "clean the garage", tone: "whiny"})
         end
       end
@@ -257,8 +248,8 @@ RSpec.describe ModelContextProtocol::Server::Prompt do
     end
 
     it "does not include title in serialized response when not provided" do
-      logger = double("logger")
-      response = prompt_without_title.call({}, logger)
+      double("logger")
+      response = prompt_without_title.call({}, client_logger)
       expect(response.serialized).not_to have_key(:title)
     end
   end

--- a/spec/lib/model_context_protocol/server/registry_spec.rb
+++ b/spec/lib/model_context_protocol/server/registry_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
         prompts do
           15.times do |i|
             prompt_class = Class.new(ModelContextProtocol::Server::Prompt) do
-              define_method(:call) do |args, logger, context|
+              define_method(:call) do |args, client_logger, context|
                 ModelContextProtocol::Server::GetPromptResponse[
                   description: "Test prompt #{i}",
                   messages: [
@@ -359,7 +359,7 @@ RSpec.describe ModelContextProtocol::Server::Registry do
         tools do
           20.times do |i|
             tool_class = Class.new(ModelContextProtocol::Server::Tool) do
-              define_method(:call) do |args, logger, context|
+              define_method(:call) do |args, client_logger, context|
                 ModelContextProtocol::Server::CallToolResponse[
                   content: [
                     {

--- a/spec/lib/model_context_protocol/server/stdio_transport_spec.rb
+++ b/spec/lib/model_context_protocol/server/stdio_transport_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
 
   let(:router) { ModelContextProtocol::Server::Router.new }
   let(:configuration) { ModelContextProtocol::Server::Configuration.new }
-  let(:mcp_logger) { configuration.logger }
+  let(:client_logger) { configuration.client_logger }
 
   before do
     @original_stdin = $stdin
@@ -97,7 +97,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
       end
 
       it "sends an error response" do
-        allow(mcp_logger).to receive(:error)
+        allow(client_logger).to receive(:error)
 
         begin
           transport.handle
@@ -115,7 +115,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
           expect(error_response).to include("error")
           expect(error_response["error"]["code"]).to eq(-32700)
           expect(error_response["error"]["message"]).to include("unexpected token")
-          expect(mcp_logger).to have_received(:error).with("Parser error", error: String)
+          expect(client_logger).to have_received(:error).with("Parser error", error: String)
         end
       end
     end
@@ -129,7 +129,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
       end
 
       it "sends a validation error response" do
-        allow(mcp_logger).to receive(:error)
+        allow(client_logger).to receive(:error)
 
         begin
           transport.handle
@@ -145,7 +145,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
           expect(response_json).to include("error")
           expect(response_json["error"]["code"]).to eq(-32602)
           expect(response_json["error"]["message"]).to eq("Invalid parameters")
-          expect(mcp_logger).to have_received(:error).with("Validation error", error: "Invalid parameters")
+          expect(client_logger).to have_received(:error).with("Validation error", error: "Invalid parameters")
         end
       end
     end
@@ -159,7 +159,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
       end
 
       it "sends an internal error response" do
-        allow(mcp_logger).to receive(:error)
+        allow(client_logger).to receive(:error)
 
         begin
           transport.handle
@@ -175,7 +175,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
           expect(response_json).to include("error")
           expect(response_json["error"]["code"]).to eq(-32603)
           expect(response_json["error"]["message"]).to eq("Something went wrong")
-          expect(mcp_logger).to have_received(:error).with("Internal error",
+          expect(client_logger).to have_received(:error).with("Internal error",
             error: "Something went wrong",
             backtrace: kind_of(Array))
         end
@@ -221,7 +221,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
 
   describe "MCP logging integration" do
     it "connects the logger to the transport when handle starts" do
-      expect(mcp_logger).to receive(:connect_transport).with(transport)
+      expect(client_logger).to receive(:connect_transport).with(transport)
 
       begin
         transport.handle
@@ -232,8 +232,7 @@ RSpec.describe ModelContextProtocol::Server::StdioTransport do
 
     describe "#send_notification" do
       before do
-        # Connect logger so notifications can be sent
-        mcp_logger.connect_transport(transport)
+        client_logger.connect_transport(transport)
       end
 
       it "sends MCP notifications to stdout" do

--- a/spec/lib/model_context_protocol/server/streamable_http_transport_spec.rb
+++ b/spec/lib/model_context_protocol/server/streamable_http_transport_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
   end
   let(:router) { server.router }
   let(:mock_redis) { MockRedis.new }
-  let(:mcp_logger) { server.configuration.logger }
+  let(:client_logger) { server.configuration.client_logger }
   let(:rack_env) { build_rack_env }
   let(:session_id) { "test-session-123" }
   let(:configuration) { server.configuration }
@@ -378,7 +378,7 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
             "active_stream" => false.to_json
           })
 
-          allow(mcp_logger).to receive(:error)
+          allow(client_logger).to receive(:error)
         end
 
         it "returns internal server error" do
@@ -391,7 +391,7 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
               error: {code: -32603, message: "Internal error"}
             })
             expect(result[:status]).to eq(500)
-            expect(mcp_logger).to have_received(:error).with("Error handling POST request",
+            expect(client_logger).to have_received(:error).with("Error handling POST request",
               error: String,
               backtrace: kind_of(Array))
           end
@@ -767,7 +767,7 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
     end
 
     it "connects the logger to the transport when handle starts" do
-      expect(mcp_logger).to receive(:connect_transport).with(transport)
+      expect(client_logger).to receive(:connect_transport).with(transport)
 
       transport.handle
     end
@@ -777,7 +777,7 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
       let(:session_id) { "test-session-123" }
 
       before do
-        mcp_logger.connect_transport(transport)
+        client_logger.connect_transport(transport)
       end
 
       context "when there are active streams" do
@@ -872,19 +872,19 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
       end
 
       it "uses MCP logger for stream monitor errors" do
-        allow(mcp_logger).to receive(:error)
+        allow(client_logger).to receive(:error)
 
-        mcp_logger.error("Stream monitor error", error: "monitor error")
+        client_logger.error("Stream monitor error", error: "monitor error")
 
-        expect(mcp_logger).to have_received(:error).with("Stream monitor error", error: "monitor error")
+        expect(client_logger).to have_received(:error).with("Stream monitor error", error: "monitor error")
       end
 
       it "uses MCP logger for message poller errors" do
-        allow(mcp_logger).to receive(:error)
+        allow(client_logger).to receive(:error)
 
-        mcp_logger.error("Error in message polling", error: "polling error")
+        client_logger.error("Error in message polling", error: "polling error")
 
-        expect(mcp_logger).to have_received(:error).with("Error in message polling",
+        expect(client_logger).to have_received(:error).with("Error in message polling",
           error: "polling error")
       end
     end
@@ -1033,8 +1033,8 @@ RSpec.describe ModelContextProtocol::Server::StreamableHttpTransport do
     end
 
     before do
-      allow(mcp_logger).to receive(:debug)
-      allow(mcp_logger).to receive(:error)
+      allow(client_logger).to receive(:debug)
+      allow(client_logger).to receive(:error)
     end
 
     describe "#handle_cancellation" do

--- a/spec/lib/model_context_protocol/server_spec.rb
+++ b/spec/lib/model_context_protocol/server_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ModelContextProtocol::Server do
           "params" => {"level" => "debug"}
         }
 
-        expect(server.configuration.logger).to receive(:set_mcp_level).with("debug")
+        expect(server.configuration.client_logger).to receive(:set_mcp_level).with("debug")
         response = server.router.route(message)
         expect(response.serialized).to eq({})
       end

--- a/spec/lib/model_context_protocol/server_spec.rb
+++ b/spec/lib/model_context_protocol/server_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe ModelContextProtocol::Server do
         tools do
           15.times do |i|
             tool_class = Class.new(ModelContextProtocol::Server::Tool) do
-              define_method(:call) do |args, logger, context|
+              define_method(:call) do |args, client_logger, context|
                 ModelContextProtocol::Server::CallToolResponse[
                   content: [
                     {
@@ -499,7 +499,7 @@ RSpec.describe ModelContextProtocol::Server do
         prompts do
           30.times do |i|
             prompt_class = Class.new(ModelContextProtocol::Server::Prompt) do
-              define_method(:call) do |args, logger, context|
+              define_method(:call) do |args, client_logger, context|
                 ModelContextProtocol::Server::GetPromptResponse[
                   description: "Test prompt #{i}",
                   messages: [

--- a/spec/support/prompts/test_prompt.rb
+++ b/spec/support/prompts/test_prompt.rb
@@ -44,8 +44,8 @@ class TestPrompt < ModelContextProtocol::Server::Prompt
 
   # The call method is invoked by the MCP Server to generate a response to resource/read requests
   def call
-    # You can use the logger
-    logger.info("Brainstorming excuses...")
+    # You can use the client_logger
+    client_logger.info("Brainstorming excuses...")
 
     # Build an array of user and assistant messages
     messages = message_history do

--- a/spec/support/resources/test_resource.rb
+++ b/spec/support/resources/test_resource.rb
@@ -8,6 +8,13 @@ class TestResource < ModelContextProtocol::Server::Resource
   end
 
   def call
+    client_logger.info("Accessing top secret plans")
+    user_id = context[:user_id]
+
+    if user_id
+      client_logger.info("User #{user_id} is accessing secret plans")
+    end
+
     respond_with text: "I'm finna eat all my wife's leftovers."
   end
 end

--- a/spec/support/tools/test_tool_with_cancellable_short_sleep.rb
+++ b/spec/support/tools/test_tool_with_cancellable_short_sleep.rb
@@ -13,7 +13,7 @@ class TestToolWithCancellableShortSleep < ModelContextProtocol::Server::Tool
   end
 
   def call
-    logger.info("Starting 2 second sleep operation")
+    client_logger.info("Starting 2 second sleep operation")
 
     result = cancellable do
       sleep 2

--- a/spec/support/tools/test_tool_with_cancellable_sleep.rb
+++ b/spec/support/tools/test_tool_with_cancellable_sleep.rb
@@ -13,7 +13,7 @@ class TestToolWithCancellableSleep < ModelContextProtocol::Server::Tool
   end
 
   def call
-    logger.info("Starting 60 second sleep operation")
+    client_logger.info("Starting 60 second sleep operation")
 
     result = cancellable do
       sleep 60

--- a/spec/support/tools/test_tool_with_mixed_content_response.rb
+++ b/spec/support/tools/test_tool_with_mixed_content_response.rb
@@ -16,7 +16,7 @@ class TestToolWithMixedContentResponse < ModelContextProtocol::Server::Tool
   end
 
   def call
-    logger.info("Getting comprehensive temperature history data")
+    client_logger.info("Getting comprehensive temperature history data")
 
     zip = arguments[:zip]
     temperature_history = retrieve_temperature_history(zip:)

--- a/spec/support/tools/test_tool_with_progressable_and_cancellable.rb
+++ b/spec/support/tools/test_tool_with_progressable_and_cancellable.rb
@@ -25,17 +25,17 @@ class TestToolWithProgressableAndCancellable < ModelContextProtocol::Server::Too
     max_duration = arguments[:max_duration] || 10
     work_steps = arguments[:work_steps] || 10
 
-    logger.info("Starting progressable call with max_duration=#{max_duration}, work_steps=#{work_steps}")
+    client_logger.info("Starting progressable call with max_duration=#{max_duration}, work_steps=#{work_steps}")
 
     context = Thread.current[:mcp_context]
-    logger.info("MCP Context: #{context.inspect}")
+    client_logger.info("MCP Context: #{context.inspect}")
 
     result = progressable(max_duration:, message: "Processing #{work_steps} items") do
       cancellable do
         processed_items = []
 
         work_steps.times do |i|
-          logger.info("Processing item #{i + 1} of #{work_steps}")
+          client_logger.info("Processing item #{i + 1} of #{work_steps}")
           sleep(max_duration / work_steps.to_f)
           processed_items << "item_#{i + 1}"
         end

--- a/spec/support/tools/test_tool_with_progressive_cancellable.rb
+++ b/spec/support/tools/test_tool_with_progressive_cancellable.rb
@@ -24,7 +24,7 @@ class TestToolWithProgressableAndCancellable < ModelContextProtocol::Server::Too
   def call
     max_duration = arguments[:max_duration] || 10
     work_steps = arguments[:work_steps] || 10
-    logger.info("Starting progressable call with max_duration=#{max_duration}, work_steps=#{work_steps}")
+    client_logger.info("Starting progressable call with max_duration=#{max_duration}, work_steps=#{work_steps}")
 
     result = progressable(max_duration:, message: "Processing #{work_steps} items") do
       cancellable do

--- a/spec/support/tools/test_tool_with_resource_response.rb
+++ b/spec/support/tools/test_tool_with_resource_response.rb
@@ -29,7 +29,7 @@ class TestToolWithResourceResponse < ModelContextProtocol::Server::Tool
       return respond_with :error, text: "Resource `#{name}` not found"
     end
 
-    resource_data = resource_klass.call
+    resource_data = resource_klass.call(client_logger, context)
 
     respond_with content: embedded_resource_content(resource: resource_data)
   end

--- a/spec/support/tools/test_tool_with_structured_content_response.rb
+++ b/spec/support/tools/test_tool_with_structured_content_response.rb
@@ -45,11 +45,11 @@ class TestToolWithStructuredContentResponse < ModelContextProtocol::Server::Tool
   def call
     # Use values provided by the server as context
     user_id = context[:user_id]
-    logger.info("Initiating request for user #{user_id}...")
+    client_logger.info("Initiating request for user #{user_id}...")
 
     # Use values provided by clients as tool arguments
     location = arguments[:location]
-    logger.info("Getting weather data for #{location}...")
+    client_logger.info("Getting weather data for #{location}...")
 
     # Returns a hash that validates against the output schema
     weather_data = get_weather_data(location)

--- a/spec/support/tools/test_tool_with_text_response.rb
+++ b/spec/support/tools/test_tool_with_text_response.rb
@@ -17,7 +17,7 @@ class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
   end
 
   def call
-    logger.info("Silly user doesn't know how to double a number")
+    client_logger.info("Silly user doesn't know how to double a number")
     number = arguments[:number].to_i
     calculation = number * 2
 


### PR DESCRIPTION
This PR updates all existing references to the logger to client_logger. This will help us prepare for adding the server logging capability which will enable devs to log without sending messages to the client.

- **Rename MCPLogger to ClientLogger**
- **Update configuration to use client logger and remove unnecessary config option**
- **Update server to use client logger references**
- **Update stdio transport to use client logger references**
- **Change logger to client_logger in prompts**
- **Change logger to client_logger in tools**
- **Add client_logger to resources**
- **Update logger to client_logger in message poller**
- **Update logger to client_logger in streamable http transport**
- **Update remaining spec references**
- **Update README**
