### PR TITLE
Implement server logging capability

### DIFF
--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -158,7 +158,7 @@ module ModelContextProtocol
           raise ModelContextProtocol::Server::ParameterValidationError, "resource not found for #{uri}"
         end
 
-        resource.call(configuration.client_logger, configuration.context)
+        resource.call(configuration.client_logger, configuration.server_logger, configuration.context)
       end
 
       router.map("resources/templates/list") do |message|
@@ -215,7 +215,7 @@ module ModelContextProtocol
         configuration
           .registry
           .find_prompt(message["params"]["name"])
-          .call(symbolized_arguments, configuration.client_logger, configuration.context)
+          .call(symbolized_arguments, configuration.client_logger, configuration.server_logger, configuration.context)
       end
 
       router.map("tools/list") do |message|
@@ -248,7 +248,7 @@ module ModelContextProtocol
         configuration
           .registry
           .find_tool(message["params"]["name"])
-          .call(symbolized_arguments, configuration.client_logger, configuration.context)
+          .call(symbolized_arguments, configuration.client_logger, configuration.server_logger, configuration.context)
       end
     end
 

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -282,7 +282,11 @@ module ModelContextProtocol
 
     class << self
       def configure_redis(&block)
-        RedisConfig.configure(&block)
+        ModelContextProtocol::Server::RedisConfig.configure(&block)
+      end
+
+      def configure_server_logging(&block)
+        ModelContextProtocol::Server::GlobalConfig::ServerLogging.configure(&block)
       end
     end
   end

--- a/lib/model_context_protocol/server/global_config/server_logging.rb
+++ b/lib/model_context_protocol/server/global_config/server_logging.rb
@@ -1,0 +1,78 @@
+require "singleton"
+
+module ModelContextProtocol
+  module Server::GlobalConfig
+    class ServerLogging
+      include Singleton
+
+      class NotConfiguredError < StandardError
+        def initialize
+          super("Server logging not configured. Call ModelContextProtocol::Server.configure_server_logging first")
+        end
+      end
+
+      class LoggerConfig
+        attr_accessor :logdev, :level, :formatter, :progname
+
+        def initialize
+          @level = Logger::INFO
+          @progname = "MCP-Server"
+        end
+
+        def to_h
+          {
+            logdev: @logdev,
+            level: @level,
+            formatter: @formatter,
+            progname: @progname
+          }.compact
+        end
+      end
+
+      def self.configure(&block)
+        instance.configure(&block)
+      end
+
+      def self.configured?
+        instance.configured?
+      end
+
+      def self.logger_params
+        instance.logger_params
+      end
+
+      def self.reset!
+        instance.reset!
+      end
+
+      def configure(&block)
+        raise ArgumentError, "Configuration block required" unless block_given?
+
+        @config = LoggerConfig.new
+        yield(@config)
+        @configured = true
+      end
+
+      def configured?
+        @configured == true
+      end
+
+      def logger_params
+        raise NotConfiguredError unless configured?
+
+        @config.to_h
+      end
+
+      def reset!
+        @configured = false
+        @config = nil
+      end
+
+      private
+
+      def initialize
+        reset!
+      end
+    end
+  end
+end

--- a/lib/model_context_protocol/server/prompt.rb
+++ b/lib/model_context_protocol/server/prompt.rb
@@ -4,13 +4,14 @@ module ModelContextProtocol
     include ModelContextProtocol::Server::ContentHelpers
     include ModelContextProtocol::Server::Progressable
 
-    attr_reader :arguments, :context, :client_logger
+    attr_reader :arguments, :context, :client_logger, :server_logger
 
-    def initialize(arguments, client_logger, context = {})
+    def initialize(arguments, client_logger, server_logger, context = {})
       validate!(arguments)
       @arguments = arguments
       @context = context
       @client_logger = client_logger
+      @server_logger = server_logger
     end
 
     def call
@@ -90,8 +91,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@defined_arguments, @defined_arguments&.dup)
       end
 
-      def call(arguments, client_logger, context = {})
-        new(arguments, client_logger, context).call
+      def call(arguments, client_logger, server_logger, context = {})
+        new(arguments, client_logger, server_logger, context).call
       rescue ArgumentError => error
         raise ModelContextProtocol::Server::ParameterValidationError, error.message
       end
@@ -129,6 +130,10 @@ module ModelContextProtocol
 
       def client_logger
         @prompt_instance.client_logger
+      end
+
+      def server_logger
+        @prompt_instance.server_logger
       end
 
       def user_message(&block)

--- a/lib/model_context_protocol/server/resource.rb
+++ b/lib/model_context_protocol/server/resource.rb
@@ -3,12 +3,13 @@ module ModelContextProtocol
     include ModelContextProtocol::Server::Cancellable
     include ModelContextProtocol::Server::Progressable
 
-    attr_reader :mime_type, :uri, :client_logger, :context
+    attr_reader :mime_type, :uri, :client_logger, :server_logger, :context
 
-    def initialize(client_logger, context = {})
+    def initialize(client_logger, server_logger, context = {})
       @mime_type = self.class.mime_type
       @uri = self.class.uri
       @client_logger = client_logger
+      @server_logger = server_logger
       @context = context
     end
 
@@ -73,8 +74,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@annotations, @annotations&.dup)
       end
 
-      def call(client_logger, context = {})
-        new(client_logger, context).call
+      def call(client_logger, server_logger, context = {})
+        new(client_logger, server_logger, context).call
       end
 
       def definition

--- a/lib/model_context_protocol/server/server_logger.rb
+++ b/lib/model_context_protocol/server/server_logger.rb
@@ -1,0 +1,24 @@
+require "logger"
+require "json"
+
+module ModelContextProtocol
+  class Server::ServerLogger < Logger
+    class StdoutNotAllowedError < StandardError; end
+
+    attr_reader :logdev
+
+    def initialize(logdev: $stderr, level: Logger::INFO, formatter: nil, progname: "MCP-Server")
+      super(logdev)
+      @logdev = logdev
+
+      self.level = level
+      self.progname = progname
+
+      self.formatter = formatter || proc do |severity, datetime, progname, msg|
+        timestamp = datetime.strftime("%Y-%m-%d %H:%M:%S.%3N")
+        prog_name = progname ? "[#{progname}] " : ""
+        "#{timestamp} #{severity} #{prog_name}#{msg}\n"
+      end
+    end
+  end
+end

--- a/lib/model_context_protocol/server/tool.rb
+++ b/lib/model_context_protocol/server/tool.rb
@@ -9,13 +9,14 @@ module ModelContextProtocol
     include ModelContextProtocol::Server::ContentHelpers
     include ModelContextProtocol::Server::Progressable
 
-    attr_reader :arguments, :context, :client_logger
+    attr_reader :arguments, :context, :client_logger, :server_logger
 
-    def initialize(arguments, client_logger, context = {})
+    def initialize(arguments, client_logger, server_logger, context = {})
       validate!(arguments)
       @arguments = arguments
       @context = context
       @client_logger = client_logger
+      @server_logger = server_logger
     end
 
     def call
@@ -103,8 +104,8 @@ module ModelContextProtocol
         subclass.instance_variable_set(:@output_schema, @output_schema)
       end
 
-      def call(arguments, client_logger, context = {})
-        new(arguments, client_logger, context).call
+      def call(arguments, client_logger, server_logger, context = {})
+        new(arguments, client_logger, server_logger, context).call
       rescue JSON::Schema::ValidationError => validation_error
         raise ModelContextProtocol::Server::ParameterValidationError, validation_error.message
       rescue OutputSchemaValidationError, ModelContextProtocol::Server::ResponseArgumentsError => tool_error

--- a/spec/lib/model_context_protocol/server/content_helpers_spec.rb
+++ b/spec/lib/model_context_protocol/server/content_helpers_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ModelContextProtocol::Server::ContentHelpers do
 
   let(:helper) { test_class.new }
   let(:client_logger) { double("client_logger") }
+  let(:server_logger) { ModelContextProtocol::Server::ServerLogger.new }
 
   before do
     allow(client_logger).to receive(:info)
@@ -193,7 +194,7 @@ RSpec.describe ModelContextProtocol::Server::ContentHelpers do
   describe "#embedded_resource_content" do
     context "with valid data" do
       it "returns an EmbeddedResource content object" do
-        resource_data = TestResource.call(client_logger)
+        resource_data = TestResource.call(client_logger, server_logger)
         result = helper.embedded_resource_content(resource: resource_data)
 
         aggregate_failures do
@@ -203,7 +204,7 @@ RSpec.describe ModelContextProtocol::Server::ContentHelpers do
       end
 
       it "returns an EmbeddedResource content object with annotations" do
-        resource_data = TestResource.call(client_logger)
+        resource_data = TestResource.call(client_logger, server_logger)
         result = helper.embedded_resource_content(resource: resource_data)
 
         aggregate_failures do

--- a/spec/lib/model_context_protocol/server/global_config/server_logging_spec.rb
+++ b/spec/lib/model_context_protocol/server/global_config/server_logging_spec.rb
@@ -1,0 +1,218 @@
+require "spec_helper"
+require "tempfile"
+
+RSpec.describe ModelContextProtocol::Server::GlobalConfig::ServerLogging do
+  subject(:config_class) { described_class }
+
+  before do
+    config_class.reset!
+  end
+
+  after do
+    config_class.reset!
+  end
+
+  describe ".configure" do
+    it "stores the configuration parameters" do
+      aggregate_failures do
+        expect {
+          config_class.configure do |config|
+            config.level = "debug"
+            config.progname = "TestServer"
+          end
+        }.not_to raise_error
+        expect(config_class.configured?).to be true
+      end
+    end
+
+    it "raises error when no block is provided" do
+      expect { config_class.configure }.to raise_error(ArgumentError, "Configuration block required")
+    end
+  end
+
+  describe ".configured?" do
+    it "returns false when not configured" do
+      expect(config_class.configured?).to be false
+    end
+
+    it "returns true when configured" do
+      config_class.configure { |config| config.level = Logger::INFO }
+      expect(config_class.configured?).to be true
+    end
+  end
+
+  describe ".logger_params" do
+    context "when not configured" do
+      it "raises NotConfiguredError" do
+        expect { config_class.logger_params }.to raise_error(
+          config_class::NotConfiguredError,
+          /Server logging not configured/
+        )
+      end
+    end
+
+    context "when configured" do
+      it "returns basic configuration parameters" do
+        config_class.configure do |config|
+          config.level = Logger::DEBUG
+          config.progname = "TestServer"
+        end
+
+        params = config_class.logger_params
+        expect(params).to eq({
+          level: Logger::DEBUG,
+          progname: "TestServer"
+        })
+      end
+
+      it "returns parameters with custom output" do
+        tempfile = Tempfile.new("test_global_log")
+
+        config_class.configure do |config|
+          config.level = Logger::ERROR
+          config.logdev = tempfile
+          config.progname = "GlobalTest"
+        end
+
+        params = config_class.logger_params
+        expect(params).to eq({
+          level: Logger::ERROR,
+          logdev: tempfile,
+          progname: "GlobalTest"
+        })
+
+        tempfile.close
+        tempfile.unlink
+      end
+
+      it "returns parameters with custom formatter" do
+        custom_formatter = proc { |severity, datetime, progname, msg| "CUSTOM: #{msg}\n" }
+
+        config_class.configure do |config|
+          config.level = Logger::INFO
+          config.formatter = custom_formatter
+          config.progname = "FormatterTest"
+        end
+
+        params = config_class.logger_params
+        expect(params).to eq({
+          level: Logger::INFO,
+          formatter: custom_formatter,
+          progname: "FormatterTest"
+        })
+      end
+
+      it "returns parameters with all options configured" do
+        tempfile = Tempfile.new("test_all_options")
+        custom_formatter = proc { |severity, datetime, progname, msg| "ALL: #{severity} #{msg}\n" }
+
+        config_class.configure do |config|
+          config.level = Logger::WARN
+          config.logdev = tempfile
+          config.formatter = custom_formatter
+          config.progname = "AllOptionsTest"
+        end
+
+        params = config_class.logger_params
+        expect(params).to eq({
+          level: Logger::WARN,
+          logdev: tempfile,
+          formatter: custom_formatter,
+          progname: "AllOptionsTest"
+        })
+
+        tempfile.close
+        tempfile.unlink
+      end
+
+      it "includes default values in parameters" do
+        config_class.configure do |config|
+          config.level = Logger::WARN
+        end
+
+        params = config_class.logger_params
+        expect(params).to eq({
+          level: Logger::WARN,
+          progname: "MCP-Server"
+        })
+      end
+
+      describe "individual configuration options" do
+        it "configures level only" do
+          config_class.configure do |config|
+            config.level = Logger::FATAL
+          end
+
+          params = config_class.logger_params
+          aggregate_failures do
+            expect(params[:level]).to eq(Logger::FATAL)
+            expect(params[:progname]).to eq("MCP-Server")
+            expect(params[:logdev]).to be_nil
+            expect(params[:formatter]).to be_nil
+          end
+        end
+
+        it "configures logdev only" do
+          tempfile = Tempfile.new("logdev_only")
+
+          config_class.configure do |config|
+            config.logdev = tempfile
+          end
+
+          params = config_class.logger_params
+          aggregate_failures do
+            expect(params[:logdev]).to eq(tempfile)
+            expect(params[:level]).to eq(Logger::INFO)
+            expect(params[:progname]).to eq("MCP-Server")
+            expect(params[:formatter]).to be_nil
+          end
+
+          tempfile.close
+          tempfile.unlink
+        end
+
+        it "configures formatter only" do
+          custom_formatter = proc { |severity, datetime, progname, msg| "ONLY: #{msg}\n" }
+
+          config_class.configure do |config|
+            config.formatter = custom_formatter
+          end
+
+          params = config_class.logger_params
+          aggregate_failures do
+            expect(params[:formatter]).to eq(custom_formatter)
+            expect(params[:level]).to eq(Logger::INFO)
+            expect(params[:progname]).to eq("MCP-Server")
+            expect(params[:logdev]).to be_nil
+          end
+        end
+
+        it "configures progname only" do
+          config_class.configure do |config|
+            config.progname = "OnlyProgname"
+          end
+
+          params = config_class.logger_params
+          aggregate_failures do
+            expect(params[:progname]).to eq("OnlyProgname")
+            expect(params[:level]).to eq(Logger::INFO)
+            expect(params[:logdev]).to be_nil
+            expect(params[:formatter]).to be_nil
+          end
+        end
+      end
+    end
+  end
+
+  describe ".reset!" do
+    it "resets all configuration state" do
+      config_class.configure { |config| config.level = Logger::DEBUG }
+      expect(config_class.configured?).to be true
+
+      config_class.reset!
+
+      expect(config_class.configured?).to be false
+      expect { config_class.logger_params }.to raise_error(config_class::NotConfiguredError)
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server/resource_spec.rb
+++ b/spec/lib/model_context_protocol/server/resource_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe ModelContextProtocol::Server::Resource do
   let(:client_logger) { double("client_logger") }
+  let(:server_logger) { ModelContextProtocol::Server::ServerLogger.new }
 
   before do
     allow(client_logger).to receive(:info)
@@ -9,7 +10,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
   describe ".call" do
     it "returns the response from the instance's call method" do
-      response = TestResource.call(client_logger)
+      response = TestResource.call(client_logger, server_logger)
       aggregate_failures do
         expect(response.text).to eq("I'm finna eat all my wife's leftovers.")
         expect(response.serialized).to eq(
@@ -28,7 +29,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
   describe "#initialize" do
     it "sets mime_type and uri from class definition" do
-      resource = TestResource.new(client_logger)
+      resource = TestResource.new(client_logger, server_logger)
 
       aggregate_failures do
         expect(resource.mime_type).to eq("text/plain")
@@ -38,7 +39,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
     it "stores the client_logger and context" do
       context = {user_id: "test-user"}
-      resource = TestResource.new(client_logger, context)
+      resource = TestResource.new(client_logger, server_logger, context)
 
       aggregate_failures do
         expect(resource.client_logger).to eq(client_logger)
@@ -47,7 +48,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     end
 
     it "defaults to empty context when not provided" do
-      resource = TestResource.new(client_logger)
+      resource = TestResource.new(client_logger, server_logger)
       expect(resource.context).to eq({})
     end
   end
@@ -55,7 +56,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
   describe "responses" do
     describe "text response" do
       it "formats text responses correctly" do
-        response = TestResource.call(client_logger)
+        response = TestResource.call(client_logger, server_logger)
         expect(response.serialized).to eq(
           contents: [
             {
@@ -71,7 +72,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
 
     describe "binary response" do
       it "formats binary responses correctly" do
-        response = TestBinaryResource.call(client_logger)
+        response = TestBinaryResource.call(client_logger, server_logger)
 
         expect(response.serialized).to eq(
           contents: [
@@ -122,7 +123,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
       end
 
       it "includes annotations in serialized response" do
-        response = TestAnnotatedResource.call(client_logger)
+        response = TestAnnotatedResource.call(client_logger, server_logger)
 
         expect(response.serialized).to eq(
           contents: [
@@ -147,7 +148,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
       end
 
       it "does not include annotations in serialized response" do
-        response = TestResource.call(client_logger)
+        response = TestResource.call(client_logger, server_logger)
 
         content = response.serialized[:contents].first
         expect(content).not_to have_key(:annotations)
@@ -263,7 +264,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     it "calls client_logger.info during execution" do
       expect(client_logger).to receive(:info).with("Accessing top secret plans")
 
-      TestResource.call(client_logger)
+      TestResource.call(client_logger, server_logger)
     end
 
     it "uses context values in logging" do
@@ -273,13 +274,44 @@ RSpec.describe ModelContextProtocol::Server::Resource do
         expect(client_logger).to receive(:info).with("User test-user-123 is accessing secret plans")
       end
 
-      TestResource.call(client_logger, context)
+      TestResource.call(client_logger, server_logger, context)
     end
 
     it "handles empty context gracefully" do
       expect(client_logger).to receive(:info).with("Accessing top secret plans")
 
-      TestResource.call(client_logger, {})
+      TestResource.call(client_logger, server_logger, {})
+    end
+  end
+
+  describe "server logger integration" do
+    it "calls server_logger during execution" do
+      aggregate_failures do
+        expect(server_logger).to receive(:debug).with("Resource access requested")
+        expect(server_logger).to receive(:info).with("Serving top secret plans content")
+      end
+
+      TestResource.call(client_logger, server_logger)
+    end
+
+    it "uses context values in server logging" do
+      context = {user_id: "test-user-123"}
+      aggregate_failures do
+        expect(server_logger).to receive(:debug).with("Resource access requested")
+        expect(server_logger).to receive(:info).with("Serving top secret plans content")
+        expect(server_logger).to receive(:info).with("User test-user-123 accessed secret plans resource")
+      end
+
+      TestResource.call(client_logger, server_logger, context)
+    end
+
+    it "handles empty context gracefully in server logging" do
+      aggregate_failures do
+        expect(server_logger).to receive(:debug).with("Resource access requested")
+        expect(server_logger).to receive(:info).with("Serving top secret plans content")
+      end
+
+      TestResource.call(client_logger, server_logger, {})
     end
   end
 
@@ -305,7 +337,7 @@ RSpec.describe ModelContextProtocol::Server::Resource do
     end
 
     it "does not include title in serialized response when not provided" do
-      response = resource_without_title.call(client_logger)
+      response = resource_without_title.call(client_logger, server_logger)
       content = response.serialized[:contents].first
       expect(content).not_to have_key(:title)
     end

--- a/spec/lib/model_context_protocol/server/router_spec.rb
+++ b/spec/lib/model_context_protocol/server/router_spec.rb
@@ -190,7 +190,9 @@ RSpec.describe ModelContextProtocol::Server::Router do
 
     before do
       router.map("cancellable_test") do |_|
-        tool = TestToolWithCancellableShortSleep.new({}, double("logger", info: nil))
+        client_logger = double("logger", info: nil)
+        server_logger = ModelContextProtocol::Server::ServerLogger.new
+        tool = TestToolWithCancellableShortSleep.new({}, client_logger, server_logger)
         response = tool.call
         response.content.first.text
       end

--- a/spec/lib/model_context_protocol/server/server_logger_spec.rb
+++ b/spec/lib/model_context_protocol/server/server_logger_spec.rb
@@ -1,0 +1,152 @@
+require "spec_helper"
+require "tempfile"
+
+RSpec.describe ModelContextProtocol::Server::ServerLogger do
+  subject(:logger_class) { described_class }
+
+  describe "initialization" do
+    context "with default settings" do
+      it "creates a logger with default stderr output" do
+        logger = logger_class.new
+
+        aggregate_failures do
+          expect(logger.logdev).to eq($stderr)
+          expect(logger.level).to eq(Logger::INFO)
+          expect(logger.progname).to eq("MCP-Server")
+        end
+      end
+    end
+
+    context "with custom settings" do
+      it "accepts custom logdev parameter" do
+        logger = logger_class.new(logdev: $stderr)
+
+        expect(logger.logdev).to eq($stderr)
+      end
+
+      it "accepts custom level parameter" do
+        logger = logger_class.new(level: Logger::DEBUG)
+
+        expect(logger.level).to eq(Logger::DEBUG)
+      end
+
+      it "accepts custom progname parameter" do
+        logger = logger_class.new(progname: "TestServer")
+
+        expect(logger.progname).to eq("TestServer")
+      end
+
+      it "accepts custom output destination" do
+        tempfile = Tempfile.new("test_log")
+        logger = logger_class.new(logdev: tempfile)
+
+        expect(logger.logdev).to eq(tempfile)
+
+        tempfile.close
+        tempfile.unlink
+      end
+
+      it "accepts custom formatter" do
+        formatter = proc { |severity, datetime, progname, msg| "#{severity}: #{msg}\n" }
+        logger = logger_class.new(formatter: formatter)
+
+        expect(logger.formatter).to eq(formatter)
+      end
+
+      it "accepts all parameters together" do
+        tempfile = Tempfile.new("test_all")
+        formatter = proc { |severity, datetime, progname, msg| "CUSTOM: #{msg}\n" }
+
+        logger = logger_class.new(
+          logdev: tempfile,
+          level: Logger::WARN,
+          formatter: formatter,
+          progname: "AllParamsTest"
+        )
+
+        aggregate_failures do
+          expect(logger.logdev).to eq(tempfile)
+          expect(logger.level).to eq(Logger::WARN)
+          expect(logger.formatter).to eq(formatter)
+          expect(logger.progname).to eq("AllParamsTest")
+        end
+
+        tempfile.close
+        tempfile.unlink
+      end
+    end
+  end
+
+  describe "logging functionality" do
+    it "logs messages with default formatter" do
+      output = StringIO.new
+      logger = logger_class.new(logdev: output)
+
+      logger.info("Test message")
+
+      output.rewind
+      log_output = output.read
+      expect(log_output).to match(/INFO.*MCP-Server.*Test message/)
+    end
+
+    it "logs messages with custom formatter" do
+      output = StringIO.new
+      formatter = proc { |severity, datetime, progname, msg| "CUSTOM: #{msg}\n" }
+      logger = logger_class.new(logdev: output, formatter: formatter)
+
+      logger.info("Test message")
+
+      output.rewind
+      log_output = output.read
+      expect(log_output).to eq("CUSTOM: Test message\n")
+    end
+
+    it "respects log levels" do
+      output = StringIO.new
+      logger = logger_class.new(logdev: output, level: Logger::WARN)
+
+      logger.info("Should not appear")
+      logger.warn("Should appear")
+
+      output.rewind
+      log_output = output.read
+
+      aggregate_failures do
+        expect(log_output).not_to include("Should not appear")
+        expect(log_output).to include("Should appear")
+      end
+    end
+
+    it "supports all standard log levels" do
+      logger = logger_class.new
+
+      aggregate_failures do
+        expect { logger.debug("debug") }.not_to raise_error
+        expect { logger.info("info") }.not_to raise_error
+        expect { logger.warn("warn") }.not_to raise_error
+        expect { logger.error("error") }.not_to raise_error
+        expect { logger.fatal("fatal") }.not_to raise_error
+      end
+    end
+  end
+
+  describe "level setting" do
+    it "accepts Logger constant level names" do
+      debug_logger = logger_class.new(level: Logger::DEBUG)
+      warn_logger = logger_class.new(level: Logger::WARN)
+      fatal_logger = logger_class.new(level: Logger::FATAL)
+
+      aggregate_failures do
+        expect(debug_logger.level).to eq(Logger::DEBUG)
+        expect(warn_logger.level).to eq(Logger::WARN)
+        expect(fatal_logger.level).to eq(Logger::FATAL)
+      end
+    end
+
+    it "accepts integer level values" do
+      logger = logger_class.new(level: 3)
+
+      expect(logger.level).to eq(3)
+    end
+  end
+end

--- a/spec/lib/model_context_protocol/server_spec.rb
+++ b/spec/lib/model_context_protocol/server_spec.rb
@@ -850,4 +850,34 @@ RSpec.describe ModelContextProtocol::Server do
       expect(block_executed).to be true
     end
   end
+
+  describe ".configure_server_logging" do
+    it "delegates to GlobalConfig::ServerLogging.configure" do
+      expect(ModelContextProtocol::Server::GlobalConfig::ServerLogging).to receive(:configure)
+
+      described_class.configure_server_logging do |config|
+        config.level = Logger::DEBUG
+        config.progname = "TestServer"
+      end
+    end
+
+    it "passes the block to GlobalConfig::ServerLogging.configure" do
+      block_executed = false
+
+      allow(ModelContextProtocol::Server::GlobalConfig::ServerLogging).to receive(:configure) do |&block|
+        config = double("config")
+        allow(config).to receive(:level=)
+        allow(config).to receive(:progname=)
+        block&.call(config)
+        block_executed = true
+      end
+
+      described_class.configure_server_logging do |config|
+        config.level = Logger::DEBUG
+        config.progname = "TestServer"
+      end
+
+      expect(block_executed).to be true
+    end
+  end
 end

--- a/spec/support/prompts/test_prompt.rb
+++ b/spec/support/prompts/test_prompt.rb
@@ -47,6 +47,10 @@ class TestPrompt < ModelContextProtocol::Server::Prompt
     # You can use the client_logger
     client_logger.info("Brainstorming excuses...")
 
+    # Server logging for debugging and monitoring (not sent to client)
+    server_logger.debug("Prompt called with arguments: #{arguments}")
+    server_logger.info("Generating excuse brainstorming prompt")
+
     # Build an array of user and assistant messages
     messages = message_history do
       # Create a message with the user role
@@ -64,6 +68,11 @@ class TestPrompt < ModelContextProtocol::Server::Prompt
         # Reference any inputs from the client by accessing the appropriate key in the arguments hash
         text_content(text: "Can you generate some excuses for me?" + (arguments[:tone] ? " Make them as #{arguments[:tone]} as possible." : ""))
       end
+    end
+
+    user_id = context[:user_id]
+    if user_id
+      server_logger.info("User #{user_id} is generating excuses")
     end
 
     # Respond with the messages

--- a/spec/support/resources/test_resource.rb
+++ b/spec/support/resources/test_resource.rb
@@ -9,10 +9,16 @@ class TestResource < ModelContextProtocol::Server::Resource
 
   def call
     client_logger.info("Accessing top secret plans")
+
+    # Server logging for debugging and monitoring (not sent to client)
+    server_logger.debug("Resource access requested")
+    server_logger.info("Serving top secret plans content")
+
     user_id = context[:user_id]
 
     if user_id
       client_logger.info("User #{user_id} is accessing secret plans")
+      server_logger.info("User #{user_id} accessed secret plans resource")
     end
 
     respond_with text: "I'm finna eat all my wife's leftovers."

--- a/spec/support/tools/test_tool_with_resource_response.rb
+++ b/spec/support/tools/test_tool_with_resource_response.rb
@@ -29,7 +29,7 @@ class TestToolWithResourceResponse < ModelContextProtocol::Server::Tool
       return respond_with :error, text: "Resource `#{name}` not found"
     end
 
-    resource_data = resource_klass.call(client_logger, context)
+    resource_data = resource_klass.call(client_logger, server_logger, context)
 
     respond_with content: embedded_resource_content(resource: resource_data)
   end

--- a/spec/support/tools/test_tool_with_text_response.rb
+++ b/spec/support/tools/test_tool_with_text_response.rb
@@ -17,14 +17,23 @@ class TestToolWithTextResponse < ModelContextProtocol::Server::Tool
   end
 
   def call
-    client_logger.info("Silly user doesn't know how to double a number")
+    # Log to client (via MCP protocol) for user visibility
+    client_logger.info("Processing number doubling request")
+
+    # Log to server (stderr/file) for debugging - not sent to client
+    server_logger.debug("Tool called with arguments: #{arguments}")
+
     number = arguments[:number].to_i
+    server_logger.debug("Parsed number: #{number}")
+
     calculation = number * 2
+    server_logger.info("Calculation completed: #{number} * 2 = #{calculation}")
 
     user_id = context[:user_id]
     salutation = user_id ? "User #{user_id}, " : ""
     text_content = text_content(text: salutation << "#{number} doubled is #{calculation}")
 
+    server_logger.debug("Responding with content: #{text_content}")
     respond_with content: text_content
   end
 end


### PR DESCRIPTION
This PR adds configurable server logging. This provides developers with the ability to debug and troubleshoot their MCP servers as they build them. This capability is separate from the existing client logging functionality; server log messages are not sent to the client.

- **Allow for globally configuring server logging**
- **Implement server logger**
- **Initialize and validate server logger in configuration**
- **Add server logger to prompts, resources, and tools**
- **Add server logging to transports**
- **Update README**
